### PR TITLE
goal - fixed thymeleaf code for determining if an entry is a section

### DIFF
--- a/src/main/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/v1/classes/Section.java
+++ b/src/main/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/v1/classes/Section.java
@@ -69,4 +69,8 @@ public class Section {
 
     public Section() {
     }
+
+    public boolean isSection(){
+        return (Integer.parseInt(this.section) % 100 != 0);
+    }
 }

--- a/src/main/resources/templates/searchResults.html
+++ b/src/main/resources/templates/searchResults.html
@@ -104,10 +104,10 @@
                       <span th:text=${tl.room}></span>
                     </td>
                     <!-- th:if to only have the add and drop by sections, not lectures -->
-                    <td th:if="${s.secondaryStatus == NULL}">
+                    <td th:if="${s.isSection()}">
                       <button type="button" class="btn btn-primary" id="js-add-course">Add</button>
                     </td>
-                    <td th:if="${s.secondaryStatus == NULL}">
+                    <td th:if="${s.isSection()}">
                       <button type="button" class="btn btn-primary" id="js-drop-course">Drop</button>
                     </td>
 


### PR DESCRIPTION
This is a small PR fixing the check for when an entry in the list of meeting times for a course is a section or not. 

the previous check, s.secondaryStatus where s is a meeting time for a course, was not guaranteed to work. The new check depends on the value of a section for that meeting time (ends with 00 iff a lecture), and is more consistent.