### PR TITLE
pc/xq - add GitHub OAuth config to sample json

### DIFF
--- a/heroku.json.SAMPLE
+++ b/heroku.json.SAMPLE
@@ -1,3 +1,6 @@
 {
- "ucsb.api.consumer_key":"fill-it-in" 
+    "spring.security.oauth2.client.registration.github.client-id":"copy-from-github",
+    "spring.security.oauth2.client.registration.github.client-secret":"copy-from-github",
+    "app_github_org":"ucsb-cs56-f19",
+    "ucsb.api.consumer_key":"fill-it-in" 
 }

--- a/localhost.json.SAMPLE
+++ b/localhost.json.SAMPLE
@@ -1,3 +1,6 @@
 {
- "ucsb.api.consumer_key":"fill-it-in" 
+    "spring.security.oauth2.client.registration.github.client-id":"copy-from-github",
+    "spring.security.oauth2.client.registration.github.client-secret":"copy-from-github",
+    "app_github_org":"ucsb-cs56-f19",
+    "ucsb.api.consumer_key":"fill-it-in" 
 }


### PR DESCRIPTION
This PR adds placeholders to the sample json for heroku and localhost where the
values of the GitHub OAuth client id and secret should be entered.