### PR TITLE
ag - buttons show up if logged in

### DIFF
--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/Application.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/Application.java
@@ -20,7 +20,7 @@ public class Application extends WebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity http) throws Exception {
     http
     .authorizeRequests()
-        .antMatchers("/","/greeting", "/login**","/webjars/**","/error**")
+        .antMatchers("/","/greeting", "/login**","/webjars/**","/error**", "/searchResults**")
         .permitAll()
     .anyRequest()
         .authenticated()

--- a/src/main/resources/templates/searchResults.html
+++ b/src/main/resources/templates/searchResults.html
@@ -104,10 +104,10 @@
                       <span th:text=${tl.room}></span>
                     </td>
                     <!-- th:if to only have the add and drop by sections, not lectures -->
-                    <td th:if="${s.isSection()}">
+                    <td th:if="${s.isSection() && isLoggedIn}">
                       <button type="button" class="btn btn-primary" id="js-add-course">Add</button>
                     </td>
-                    <td th:if="${s.isSection()}">
+                    <td th:if="${s.isSection() && isLoggedIn}">
                       <button type="button" class="btn btn-primary" id="js-drop-course">Drop</button>
                     </td>
 


### PR DESCRIPTION
This PR adds a feature that "Add" and "Drop" buttons show up by sections only if the user is authenticated. 

Changes:
* Add and drop buttons will not show up if the user is not logged in
* *searchResults* page is whitelisted for when you are not authenticated: you are still able to see a list of courses without having to log in.