### PR TITLE
pc - add method to get instructor from first section on list

### DIFF
--- a/src/main/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/v1/classes/Course.java
+++ b/src/main/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/v1/classes/Course.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import lombok.Data;
 
@@ -11,5 +12,31 @@ public class Course {
     public String title;
     public List<Section> classSections;
 
-    public Course () {}
+    public Course() {
+    }
+
+    /**
+     * Provided that there is at least one section in the list of sections, and that
+     * the first section has at least one instructor in the list of instructors,
+     * return a list of all of the instructors for the first section, separated by a
+     * comma and a single space between each name.  Otherwise, returns an empty string.
+     * 
+     * @return instructor(s) of first section
+     */
+    public String mainInstructorList() {
+        if (classSections == null)
+            return "";
+        if (classSections.size() == 0)
+            return "";
+        Section firstSection = classSections.get(0);
+        if (firstSection.instructors == null)
+            return "";
+        if (firstSection.instructors.size() == 0)
+            return "";
+
+        List<Instructor> instructors = firstSection.instructors;
+        List<String> instructorNames = instructors.stream().map((i) -> i.instructor).collect(Collectors.toList());
+        String instructorsCommaSeparated = String.join(", ", instructorNames);
+        return instructorsCommaSeparated;
+    }
 }

--- a/src/test/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/v1/classes/TestCourse.java
+++ b/src/test/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/v1/classes/TestCourse.java
@@ -1,0 +1,89 @@
+package edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+import java.util.ArrayList;
+
+public class TestCourse {
+
+    @Test
+    public void test_mainInstructorList__null_section_returns_empty_string() {
+        Course c = new Course();
+        assertEquals(null, c.classSections);
+
+        assertEquals("", c.mainInstructorList());
+    }
+
+    @Test
+    public void test_mainInstructorList__empty_section_returns_empty_string() {
+        Course c = new Course();
+        c.classSections = new ArrayList<Section>();
+        assertEquals(0, c.classSections.size());
+    
+        assertEquals("", c.mainInstructorList());
+    }
+
+    @Test
+    public void test_mainInstructorList__first_section_null_instructor_list_returns_empty_string() {
+        Section s = new Section();
+        Course c = new Course();
+        c.classSections = new ArrayList<Section>();
+        c.classSections.add(s);
+        assertEquals(null, s.instructors);
+            
+        assertEquals("", c.mainInstructorList());
+    }
+
+    @Test
+    public void test_mainInstructorList__first_section_empty_instructor_list_returns_empty_string() {
+        Section s = new Section();
+        s.instructors = new ArrayList<Instructor>();
+        Course c = new Course();
+        c.classSections = new ArrayList<Section>();
+        c.classSections.add(s);
+            
+        assertEquals("", c.mainInstructorList());
+            
+        assertEquals("", c.mainInstructorList());
+    }
+
+    @Test
+    public void test_mainInstructorList__first_section_single_instructor() {
+        Instructor i = new Instructor();
+        i.instructor = "GAUCHO C";
+        Section s = new Section();
+        s.instructors = new ArrayList<Instructor>();
+        s.instructors.add(i);
+        Course c = new Course();
+        c.classSections = new ArrayList<Section>();
+        c.classSections.add(s);
+            
+        assertEquals("GAUCHO C", c.mainInstructorList());            
+    }
+
+    @Test
+    public void test_mainInstructorList__first_section_multiple_instructors() {
+        Instructor i1 = new Instructor();
+        Instructor i2 = new Instructor();
+        Instructor i3 = new Instructor();
+
+        i1.instructor = "GAUCHO A";
+        i2.instructor = "OLE B";
+        i3.instructor = "SURFER C";
+
+        Section s = new Section();
+        s.instructors = new ArrayList<Instructor>();
+        s.instructors.add(i1);
+        s.instructors.add(i2);
+        s.instructors.add(i3);
+
+        Course c = new Course();
+        c.classSections = new ArrayList<Section>();
+        c.classSections.add(s);
+            
+        assertEquals("GAUCHO A, OLE B, SURFER C", c.mainInstructorList());            
+    }
+}


### PR DESCRIPTION
In this PR, we add some methods to the `Course` object, along with test coverage of these methods.  This allow us to more easily list the "main instructor" in summary listing of courses.