### PR TITLE
Pc search by course

### DIFF
--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/CurriculumService.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/CurriculumService.java
@@ -3,4 +3,5 @@ package edu.ucsb.cs56.ucsb_courses_search;
 public interface CurriculumService {
     public String getJSON(String subjectArea, String quarter, String courseLevel);
     public String getJSON(String instructor, String quarter);
+    public String getCourse(String course, int quarter);
 }

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/UCSBAcademicCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/UCSBAcademicCurriculumService.java
@@ -43,15 +43,16 @@ public class UCSBAcademicCurriculumService implements CurriculumService {
         HttpEntity<String> entity = new HttpEntity<>("body", headers);
 
         String uri = "https://api.ucsb.edu/academics/curriculums/v1/classes/search";
-        String params = String.format("?quarter=%s&subjectCode=%s&objLevelCode=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s",
-            quarter, subjectArea, courseLevel, 1, 100, "true");
+        String params = String.format(
+                "?quarter=%s&subjectCode=%s&objLevelCode=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s", quarter,
+                subjectArea, courseLevel, 1, 100, "true");
         String url = uri + params;
         logger.info("url=" + url);
 
-        String retVal="";
+        String retVal = "";
         try {
             ResponseEntity<String> re = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
-             MediaType contentType = re.getHeaders().getContentType();
+            MediaType contentType = re.getHeaders().getContentType();
             HttpStatus statusCode = re.getStatusCode();
             retVal = re.getBody();
         } catch (HttpClientErrorException e) {
@@ -61,8 +62,8 @@ public class UCSBAcademicCurriculumService implements CurriculumService {
         return retVal;
     }
 
-    public String getJSON(String instructor, String quarter){
-        logger.info("api: "+apiKey);
+    public String getJSON(String instructor, String quarter) {
+        logger.info("api: " + apiKey);
         RestTemplate restTemplate = new RestTemplate();
 
         HttpHeaders headers = new HttpHeaders();
@@ -74,15 +75,57 @@ public class UCSBAcademicCurriculumService implements CurriculumService {
         HttpEntity<String> entity = new HttpEntity<>("body", headers);
 
         String uri = "https://api.ucsb.edu/academics/curriculums/v1/classes/search";
-        String params = String.format("?quarter=%s&instructor=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s", quarter,
-        instructor, 1, 100, "true");
+        String params = String.format("?quarter=%s&instructor=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s",
+                quarter, instructor, 1, 100, "true");
         String url = uri + params;
         logger.info("url=" + url);
 
-        String retVal="";
-        try {   
+        String retVal = "";
+        try {
             ResponseEntity<String> re = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
-             MediaType contentType = re.getHeaders().getContentType();
+            MediaType contentType = re.getHeaders().getContentType();
+            HttpStatus statusCode = re.getStatusCode();
+            retVal = re.getBody();
+        } catch (HttpClientErrorException e) {
+            retVal = "{\"error\": \"401: Unauthorized\"}";
+        }
+        logger.info("from UCSBAcademicCurriculumService.getJSON: " + retVal);
+        return retVal;
+    }
+
+    /**
+     * Gets the json response for a query for a given course in a given quarter.
+     * 
+     * @param course  name of course, e.g. "CMPSC 130A"
+     * @param quarter quarter as an integer, e.g. 20201 for W20
+     * @return json results from API
+     */
+
+    public String getCourse(String course, int quarter) {
+        logger.info("api: " + apiKey);
+        logger.info("getCourse: course: " + course + " quarter: " + quarter);
+
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("ucsb-api-version", "1.0");
+        headers.set("ucsb-api-key", this.apiKey);
+
+        HttpEntity<String> entity = new HttpEntity<>("body", headers);
+
+        String uri = "https://api.ucsb.edu/academics/curriculums/v1/classes/search";
+        String params = String.format("?quarter=%d&courseId=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s",
+                quarter, course, 1, 100, "true");
+
+        String url = uri + params;
+        logger.info("url=" + url);
+
+        String retVal = "";
+        try {
+            ResponseEntity<String> re = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+            MediaType contentType = re.getHeaders().getContentType();
             HttpStatus statusCode = re.getStatusCode();
             retVal = re.getBody();
         } catch (HttpClientErrorException e) {

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/SearchByCourseController.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/SearchByCourseController.java
@@ -1,0 +1,63 @@
+package edu.ucsb.cs56.ucsb_courses_search.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import edu.ucsb.cs56.ucsb_courses_search.CurriculumService;
+import edu.ucsb.cs56.ucsb_courses_search.searches.SearchByCourse;
+import edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes.Course;
+import edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes.CoursePage;
+import edu.ucsb.cs56.ucsbapi.academics.curriculums.utilities.Quarter;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Controller
+public class SearchByCourseController {
+
+    private Logger logger = LoggerFactory.getLogger(SearchByCourseController.class);
+
+    @Autowired   
+    private CurriculumService curriculumService;
+
+    
+    @GetMapping("/search/bycourse")
+    public String instructor(Model model, SearchByCourse searchByCourse) {
+    	model.addAttribute("searchByCourse", new SearchByCourse());
+        return "search/bycourse/search"; 
+    }
+
+    @GetMapping("/search/bycourse/results")
+    public String search(
+        @RequestParam(name = "course", required = true) 
+        String course,
+        @RequestParam(name = "beginQ", required = true) 
+        int beginQ,
+        @RequestParam(name = "endQ", required = true) 
+        int endQ,
+        Model model, SearchByCourse searchByCourse
+        ) {
+        model.addAttribute("course", course);
+        model.addAttribute("beginQ", beginQ);
+        model.addAttribute("endQ", endQ);
+
+        List<Course> courses = new ArrayList<Course>();
+        for(Quarter qtr = new Quarter(beginQ); qtr.getValue() <= endQ; qtr.increment()) {
+            String json = curriculumService.getCourse(course, qtr.getValue());   
+            logger.info("qtr=" + qtr.getValue() + " json="+json);         
+            CoursePage cp = CoursePage.fromJSON(json);
+            courses.addAll(cp.classes);
+        }
+        
+        model.addAttribute("courses",courses);
+        return "search/bycourse/results"; 
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/searches/SearchByCourse.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/searches/SearchByCourse.java
@@ -1,0 +1,62 @@
+package edu.ucsb.cs56.ucsb_courses_search.searches;
+
+import java.util.Objects;
+
+public class SearchByCourse {
+
+    public SearchByCourse() {}
+
+    private int beginQ;
+    private int endQ;
+    private String course;
+
+    public int getBeginQ() {
+        return this.beginQ;
+    }
+
+    public void setBeginQ(int beginQ) {
+        this.beginQ = beginQ;
+    }
+
+    public int getEndQ() {
+        return this.endQ;
+    }
+
+    public void setEndQ(int endQ) {
+        this.endQ = endQ;
+    }
+
+    public String getCourse() {
+        return this.course;
+    }
+
+    public void setCourse(String course) {
+        this.course = course;
+    }
+
+    @Override
+    public String toString() {
+        return "{" +
+            " beginQ='" + beginQ + "'" +
+            ", endQ='" + endQ + "'" +
+            ", course='" + course + "'" +
+            "}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this)
+            return true;
+        if (!(o instanceof SearchByCourse)) {
+            return false;
+        }
+        SearchByCourse searchByCourse = (SearchByCourse) o;
+        return beginQ == searchByCourse.beginQ && endQ == searchByCourse.endQ && Objects.equals(course, searchByCourse.course);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(beginQ, endQ, course);
+    }
+   
+} 

--- a/src/main/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/utilities/Quarter.java
+++ b/src/main/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/utilities/Quarter.java
@@ -1,0 +1,81 @@
+package edu.ucsb.cs56.ucsbapi.academics.curriculums.utilities;
+
+/**
+ * Represents a UCSB quarter. Allows easy conversion between QYY alphanumeric
+ * format (F19, W20, S20, M20) and YYYYQ numerical format (20194, 20201, 20202,
+ * 20203) as well as incrementing and decrementing.
+ *
+ */
+
+public class Quarter {
+
+    private int yyyyq; // YYYYQ where Q = 1, 2, 3 or 4
+
+    public Quarter(int yyyyq) {
+        setValue(yyyyq);
+    }
+
+    public int getValue() {
+        return this.yyyyq;
+    }
+
+    public void setValue(int yyyyq) {
+        if (invalidQtr(yyyyq))
+            throw new IllegalArgumentException("Quarter constructor requires a integer ending in 1,2,3 or 4");
+        this.yyyyq = yyyyq;
+    }
+
+    public Quarter(String qyy) {
+        if (qyy.length() != 3) {
+            throw new IllegalArgumentException("Quarter requires string of length 3");
+        }
+        char q = qyy.charAt(0);
+        String yy = qyy.substring(1, 3);
+        String legalQuarters = "WSMF";
+        int qInt = legalQuarters.indexOf(q) + 1;
+        if (invalidQtr(qInt)) {
+            throw new IllegalArgumentException("First char should be one of " + legalQuarters);
+        }
+        int yyInt = Integer.parseInt(yy);
+        int century = (yyInt > 50) ? 1900 : 2000;
+        this.yyyyq = (century + yyInt) * 10 + qInt;
+    }
+
+    public String getYY() {
+        return String.format("%02d", (yyyyq / 10) % 100);
+    }
+
+    public String getYYYY() {
+        return String.format("%04d", (yyyyq / 10));
+    }
+
+    public String toString() {
+        return String.format("%s%s", getQ(), getYY());
+    }
+
+    public String getQ() {
+        String[] quarters = new String[] { "W", "S", "M", "F" };
+        int index = yyyyq % 10;
+        if (index < 1 || index > 4)
+            throw new IllegalStateException("Invalid value for quarter " + index);
+        return quarters[index - 1];
+    }
+
+    private static boolean invalidQtr(int value) {
+        int index = value % 10;
+        return (index < 1) || (index > 4);
+    }
+
+    /**
+     * Advance to the next quater, and return the value of that quarter as an int.
+     * @return
+     */
+    public int increment() {
+        int q = this.yyyyq % 10;
+        int yyyy = this.yyyyq / 10;
+
+        setValue( (q==4) ? (((yyyy + 1) * 10) + 1 ) : (this.yyyyq + 1) );
+        return this.yyyyq;
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/v1/classes/Course.java
+++ b/src/main/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/v1/classes/Course.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import lombok.Data;
 
@@ -11,5 +12,31 @@ public class Course {
     public String title;
     public List<Section> classSections;
 
-    public Course () {}
+    public Course() {
+    }
+
+    /**
+     * Provided that there is at least one section in the list of sections, and that
+     * the first section has at least one instructor in the list of instructors,
+     * return a list of all of the instructors for the first section, separated by a
+     * comma and a single space between each name.  Otherwise, returns an empty string.
+     * 
+     * @return instructor(s) of first section
+     */
+    public String mainInstructorList() {
+        if (classSections == null)
+            return "";
+        if (classSections.size() == 0)
+            return "";
+        Section firstSection = classSections.get(0);
+        if (firstSection.instructors == null)
+            return "";
+        if (firstSection.instructors.size() == 0)
+            return "";
+
+        List<Instructor> instructors = firstSection.instructors;
+        List<String> instructorNames = instructors.stream().map((i) -> i.instructor).collect(Collectors.toList());
+        String instructorsCommaSeparated = String.join(", ", instructorNames);
+        return instructorsCommaSeparated;
+    }
 }

--- a/src/main/resources/templates/fragments/bootstrap_nav_header.html
+++ b/src/main/resources/templates/fragments/bootstrap_nav_header.html
@@ -11,7 +11,7 @@
         <ul class="navbar-nav mr-auto">
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                Instructor
+                Search by Instructor
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                 <a class="dropdown-item" href="/instructor/search">Basic Instructor Search</a>
@@ -21,7 +21,7 @@
             </li>
             <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                  Team 2
+                  Personal Schedule
                 </a>
                 <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                   <a class="dropdown-item" href="/courseschedule">See Your Schedule</a>
@@ -32,13 +32,10 @@
               </li>
               <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                  Team 3
+                  Search by Course
                 </a>
                 <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                  <a class="dropdown-item" href="#">Action</a>
-                  <a class="dropdown-item" href="#">Another action</a>
-                  <div class="dropdown-divider"></div>
-                  <a class="dropdown-item" href="#">Something else here</a>
+                  <a class="dropdown-item" href="/search/bycourse">Search by Course</a>
                 </div>
               </li>
               <li class="nav-item dropdown">

--- a/src/main/resources/templates/search/bycourse/fragments/form.html
+++ b/src/main/resources/templates/search/bycourse/fragments/form.html
@@ -1,0 +1,50 @@
+<form method="GET" th:object="${searchByCourse}">
+    <div class="form-group row">
+        <label for="course" class="col-sm-2 col-form-label">Course</label>
+        <div class="col-sm-10">
+            <input type="text" th:field="*{course}" class="form-control" id="course">
+        </div>
+    </div>
+    <div class="form-group row">
+        <label for="beginQ" class="col-sm-2 col-form-label">Begin Quarter</label>
+        <div class="col-sm-10">
+            <select th:field="*{beginQ}" class="custom-select">
+                <option selected="selected" value="20201">WINTER 2020</option>
+                <option value="20194">FALL 2019 </option>
+                <option value="20193">SUMMER 2019 </option>
+                <option value="20192">SPRING 2019 </option>
+                <option value="20191">WINTER 2019 </option>
+                <option value="20184">FALL 2018 </option>
+                <option value="20183">SUMMER 2018 </option>
+                <option value="20182">SPRING 2018 </option>
+                <option value="20181">WINTER 2018 </option>
+                <option value="20174">FALL 2017 </option>
+            </select>
+        </div>
+    </div>
+    <div class="form-group row">
+        <label for="endQ" class="col-sm-2 col-form-label">End Quarter</label>
+        <div class="col-sm-10">
+            <select th:field="*{endQ}" class="custom-select">
+                <option selected="selected" value="20201">WINTER 2020</option>
+                <option value="20194">FALL 2019 </option>
+                <option value="20193">SUMMER 2019 </option>
+                <option value="20192">SPRING 2019 </option>
+                <option value="20191">WINTER 2019 </option>
+                <option value="20184">FALL 2018 </option>
+                <option value="20183">SUMMER 2018 </option>
+                <option value="20182">SPRING 2018 </option>
+                <option value="20181">WINTER 2018 </option>
+                <option value="20174">FALL 2017 </option>
+            </select>
+        </div>
+    </div>
+    <div class="form-group row">
+        <label for="js-multi-search-submit" class="col-sm-2 col-form-label"></label>
+        <div class="col-sm-10">
+            <button type="submit" th:formaction="@{/search/bycourse/results}" class="btn btn-primary"
+                id="js-multi-search-submit">Submit</button>
+        </div>
+    </div>
+
+</form>

--- a/src/main/resources/templates/search/bycourse/fragments/list.html
+++ b/src/main/resources/templates/search/bycourse/fragments/list.html
@@ -1,0 +1,18 @@
+<table class="table">
+    <thead>
+        <tr>
+            <th>Quarter</th>
+            <th>CourseId</th>
+            <th>Title</th>
+            <th>Instructor(s)</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr th:each="c: ${courses}">
+            <td th:text="${c.quarter}"></td>
+            <td th:text="${c.courseId}"></td>
+            <td th:text="${c.title}"></td>
+            <td th:text="${c.mainInstructorList()}"></td>
+        </tr>
+    </tbody>
+</table>

--- a/src/main/resources/templates/search/bycourse/results.html
+++ b/src/main/resources/templates/search/bycourse/results.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+
+<head>
+  <title>Course Search Results</title>
+  <div th:replace="fragments/bootstrap_head.html"></div>
+</head>
+
+<body>
+  <div class="container">
+    <div th:replace="fragments/bootstrap_nav_header.html"></div>
+    <h1>Course Search</h1>
+    <p>This page allows you to search for a given course over multiple quarters.</p>
+    <div th:replace="search/bycourse/fragments/form.html"></div>
+    <div th:replace="search/bycourse/fragments/list.html"></div>
+    <div th:replace="fragments/bootstrap_footer.html"></div>
+  </div>
+  <div th:replace="fragments/bootstrap_scripts.html"></div>
+</body>
+
+</html>

--- a/src/main/resources/templates/search/bycourse/search.html
+++ b/src/main/resources/templates/search/bycourse/search.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+
+<head>
+  <title>Course Search</title>
+  <div th:replace="fragments/bootstrap_head.html"></div>
+</head>
+
+<body>
+  <div class="container">
+    <div th:replace="fragments/bootstrap_nav_header.html"></div>
+    <h1>Course Search</h1>
+    <p>This page allows you to search for a given course over multiple quarters.</p>
+    <div th:replace="search/bycourse/fragments/form.html"></div>
+    <div th:replace="fragments/bootstrap_footer.html"></div>
+  </div>
+  <div th:replace="fragments/bootstrap_scripts.html"></div>
+</body>
+
+</html>

--- a/src/test/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/utilities/TestQuarter.java
+++ b/src/test/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/utilities/TestQuarter.java
@@ -1,0 +1,99 @@
+package edu.ucsb.cs56.ucsbapi.academics.curriculums.utilities;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+import java.util.ArrayList;
+
+public class TestQuarter {
+
+    @Test
+    public void test_constructor_20194() {
+        Quarter q = new Quarter(20194);
+        assertEquals(20194, q.getValue());
+        assertEquals("F19", q.toString());
+    }
+
+    @Test
+    public void test_constructor_F19() {
+        Quarter q = new Quarter("F19");
+        assertEquals(20194, q.getValue());
+        assertEquals("F19", q.toString());
+    }
+
+    @Test
+    public void test_constructor_20201() {
+        Quarter q = new Quarter(20201);
+        assertEquals(20201, q.getValue());
+        assertEquals("W20", q.toString());
+    }
+
+    @Test
+    public void test_constructor_W20() {
+        Quarter q = new Quarter("W20");
+        assertEquals(20201, q.getValue());
+        assertEquals("W20", q.toString());
+    }
+
+
+    @Test
+    public void test_constructor_S20() {
+        Quarter q = new Quarter("S20");
+        assertEquals(20202, q.getValue());
+        assertEquals("S20", q.toString());
+    }
+
+    
+    @Test
+    public void test_constructor_M20() {
+        Quarter q = new Quarter("M20");
+        assertEquals(20203, q.getValue());
+        assertEquals("M20", q.toString());
+    }
+
+
+    @Test
+    public void test_constructor_F01() {
+        Quarter q = new Quarter("F01");
+        assertEquals(20014, q.getValue());
+        assertEquals("F01", q.toString());
+    }
+
+    @Test
+    public void test_constructor_S99() {
+        Quarter q = new Quarter("S99");
+        assertEquals(19992, q.getValue());
+        assertEquals("S99", q.toString());
+    }
+
+    @Test
+    public void test_increment_F19() {
+        Quarter q = new Quarter("F19");
+        assertEquals(20201, q.increment());
+        assertEquals("W20", q.toString());
+    }
+
+    @Test
+    public void test_increment_W20() {
+        Quarter q = new Quarter("W20");
+        assertEquals(20202, q.increment());
+        assertEquals("S20", q.toString());
+    }
+
+    @Test
+    public void test_increment_S20() {
+        Quarter q = new Quarter("S20");
+        assertEquals(20203, q.increment());
+        assertEquals("M20", q.toString());
+    }
+
+    @Test
+    public void test_increment_M20() {
+        Quarter q = new Quarter("M20");
+        assertEquals(20204, q.increment());
+        assertEquals("F20", q.toString());
+    }
+
+}

--- a/src/test/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/v1/classes/TestCourse.java
+++ b/src/test/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/v1/classes/TestCourse.java
@@ -1,0 +1,89 @@
+package edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+import java.util.ArrayList;
+
+public class TestCourse {
+
+    @Test
+    public void test_mainInstructorList__null_section_returns_empty_string() {
+        Course c = new Course();
+        assertEquals(null, c.classSections);
+
+        assertEquals("", c.mainInstructorList());
+    }
+
+    @Test
+    public void test_mainInstructorList__empty_section_returns_empty_string() {
+        Course c = new Course();
+        c.classSections = new ArrayList<Section>();
+        assertEquals(0, c.classSections.size());
+    
+        assertEquals("", c.mainInstructorList());
+    }
+
+    @Test
+    public void test_mainInstructorList__first_section_null_instructor_list_returns_empty_string() {
+        Section s = new Section();
+        Course c = new Course();
+        c.classSections = new ArrayList<Section>();
+        c.classSections.add(s);
+        assertEquals(null, s.instructors);
+            
+        assertEquals("", c.mainInstructorList());
+    }
+
+    @Test
+    public void test_mainInstructorList__first_section_empty_instructor_list_returns_empty_string() {
+        Section s = new Section();
+        s.instructors = new ArrayList<Instructor>();
+        Course c = new Course();
+        c.classSections = new ArrayList<Section>();
+        c.classSections.add(s);
+            
+        assertEquals("", c.mainInstructorList());
+            
+        assertEquals("", c.mainInstructorList());
+    }
+
+    @Test
+    public void test_mainInstructorList__first_section_single_instructor() {
+        Instructor i = new Instructor();
+        i.instructor = "GAUCHO C";
+        Section s = new Section();
+        s.instructors = new ArrayList<Instructor>();
+        s.instructors.add(i);
+        Course c = new Course();
+        c.classSections = new ArrayList<Section>();
+        c.classSections.add(s);
+            
+        assertEquals("GAUCHO C", c.mainInstructorList());            
+    }
+
+    @Test
+    public void test_mainInstructorList__first_section_multiple_instructors() {
+        Instructor i1 = new Instructor();
+        Instructor i2 = new Instructor();
+        Instructor i3 = new Instructor();
+
+        i1.instructor = "GAUCHO A";
+        i2.instructor = "OLE B";
+        i3.instructor = "SURFER C";
+
+        Section s = new Section();
+        s.instructors = new ArrayList<Instructor>();
+        s.instructors.add(i1);
+        s.instructors.add(i2);
+        s.instructors.add(i3);
+
+        Course c = new Course();
+        c.classSections = new ArrayList<Section>();
+        c.classSections.add(s);
+            
+        assertEquals("GAUCHO A, OLE B, SURFER C", c.mainInstructorList());            
+    }
+}


### PR DESCRIPTION
In this PR, we add an MVP for a search by course feature.

The third menu now has an option where a user can enter a course to search for, a starting and ending quarter.  Basic information about the courses offered in those quarters is provided.

Future enhancements may include:
* adding information about the enrollments, as well as day/time/room, etc. 
* a list of TAs, and number of sections offered
* ability to download as a CSV

For most use cases of this page it is good to preserve the one line per lecture section structure though.
