### PR TITLE
pc - add quarter in both formats to course search

### DIFF
--- a/src/main/resources/templates/search/bycourse/fragments/list.html
+++ b/src/main/resources/templates/search/bycourse/fragments/list.html
@@ -1,7 +1,8 @@
 <table class="table">
     <thead>
         <tr>
-            <th>Quarter</th>
+            <th>YYYYQ</th>
+            <th>QYY</th>
             <th>CourseId</th>
             <th>Title</th>
             <th>Instructor(s)</th>
@@ -10,6 +11,7 @@
     <tbody>
         <tr th:each="c: ${courses}">
             <td th:text="${c.quarter}"></td>
+            <td th:text="${c.getQuarterQyy()}"></td>
             <td th:text="${c.courseId}"></td>
             <td th:text="${c.title}"></td>
             <td th:text="${c.mainInstructorList()}"></td>


### PR DESCRIPTION
In this PR, we add quarter in both YYYYQ and QYY formats to the course search results.