### PR TITLE
Pc search by dept

### DIFF
--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/Application.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/Application.java
@@ -12,26 +12,16 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 public class Application extends WebSecurityConfigurerAdapter {
 
     public static void main(String[] args) {
-	SpringApplication.run(Application.class, args);
+        SpringApplication.run(Application.class, args);
     }
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-    http
-    .authorizeRequests()
-        .antMatchers("/","/greeting", "/login**","/webjars/**","/error**", "/searchResults**")
-        .permitAll()
-    .anyRequest()
-        .authenticated()
-    .and()
-        .oauth2Login().loginPage("/login")
-    .and()
-        .logout()
-        .deleteCookies("remove")
-        .invalidateHttpSession(true)
-        .logoutUrl("/logout")
-        .logoutSuccessUrl("/")
-        .permitAll();
-}
+        http.authorizeRequests()
+                .antMatchers("/", "/greeting", "/login**", "/webjars/**", "/error**", "/searchResults**", "/search**") .permitAll()
+                .anyRequest().authenticated().and().oauth2Login().loginPage("/login").and().logout()
+                .deleteCookies("remove").invalidateHttpSession(true).logoutUrl("/logout").logoutSuccessUrl("/")
+                .permitAll();
+    }
 
 }

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/Application.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/Application.java
@@ -18,10 +18,16 @@ public class Application extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.authorizeRequests()
-                .antMatchers("/", "/greeting", "/login**", "/webjars/**", "/error**", "/searchResults**", "/search**") .permitAll()
-                .anyRequest().authenticated().and().oauth2Login().loginPage("/login").and().logout()
-                .deleteCookies("remove").invalidateHttpSession(true).logoutUrl("/logout").logoutSuccessUrl("/")
-                .permitAll();
+                .antMatchers("/", "/greeting", "/login**", "/webjars/**", "/error**", "/searchResults**", "/search/**") 
+                   .permitAll()
+                .anyRequest().authenticated()
+                .and()
+                  .oauth2Login().loginPage("/login")
+                .and()
+                   .logout()
+                     .deleteCookies("remove").invalidateHttpSession(true)
+                     .logoutUrl("/logout").logoutSuccessUrl("/")
+                     .permitAll();
     }
 
 }

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/UCSBAcademicCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/UCSBAcademicCurriculumService.java
@@ -47,6 +47,14 @@ public class UCSBAcademicCurriculumService implements CurriculumService {
                 "?quarter=%s&subjectCode=%s&objLevelCode=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s", quarter,
                 subjectArea, courseLevel, 1, 100, "true");
         String url = uri + params;
+
+        if (courseLevel.equals("A")) {
+            params = String.format(
+                    "?quarter=%s&subjectCode=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s",
+                    quarter, subjectArea, 1, 100, "true");
+            url = uri + params;
+        }
+
         logger.info("url=" + url);
 
         String retVal = "";

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/SearchByDeptController.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/SearchByDeptController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import edu.ucsb.cs56.ucsb_courses_search.CurriculumService;
+import edu.ucsb.cs56.ucsb_courses_search.results.CourseOffering;
 import edu.ucsb.cs56.ucsb_courses_search.searches.SearchByDept;
 import edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes.Course;
 import edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes.CoursePage;
@@ -50,8 +51,12 @@ public class SearchByDeptController {
 
         String json = curriculumService.getJSON(dept,quarter,courseLevel);
         CoursePage cp = CoursePage.fromJSON(json);
+
+        List<CourseOffering> courseOfferings = CourseOffering.fromCoursePage(cp);
         
         model.addAttribute("cp",cp);
+        model.addAttribute("courseOfferings",courseOfferings);
+
         return "search/bydept/results"; 
     }
 

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/SearchByDeptController.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/SearchByDeptController.java
@@ -1,0 +1,58 @@
+package edu.ucsb.cs56.ucsb_courses_search.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import edu.ucsb.cs56.ucsb_courses_search.CurriculumService;
+import edu.ucsb.cs56.ucsb_courses_search.searches.SearchByDept;
+import edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes.Course;
+import edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes.CoursePage;
+import edu.ucsb.cs56.ucsbapi.academics.curriculums.utilities.Quarter;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Controller
+public class SearchByDeptController {
+
+    private Logger logger = LoggerFactory.getLogger(SearchByDeptController.class);
+
+    @Autowired   
+    private CurriculumService curriculumService;
+
+    
+    @GetMapping("/search/bydept")
+    public String instructor(Model model, SearchByDept searchByDept) {
+    	model.addAttribute("searchByDept", new SearchByDept());
+        return "search/bydept/search"; 
+    }
+
+    @GetMapping("/search/bydept/results")
+    public String search(
+        @RequestParam(name = "dept", required = true) 
+        String dept,
+        @RequestParam(name = "quarter", required = true) 
+        String quarter,
+        @RequestParam(name = "courseLevel", required = true) 
+        String courseLevel,
+        Model model, SearchByDept searchByDept
+        ) {
+        model.addAttribute("dept", dept);
+        model.addAttribute("quarter", quarter);
+        model.addAttribute("courseLevel", courseLevel);
+
+        String json = curriculumService.getJSON(dept,quarter,courseLevel);
+        CoursePage cp = CoursePage.fromJSON(json);
+        
+        model.addAttribute("cp",cp);
+        return "search/bydept/results"; 
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/results/CourseOffering.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/results/CourseOffering.java
@@ -1,0 +1,138 @@
+package edu.ucsb.cs56.ucsb_courses_search.results;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.hibernate.type.AbstractStandardBasicType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes.Section;
+import edu.ucsb.cs56.ucsbapi.academics.curriculums.utilities.Quarter;
+import edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes.Course;
+import edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes.CoursePage;
+import edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes.Instructor;
+import edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes.TimeLocation;
+
+
+public class CourseOffering {
+    private Course course;
+    private Section primary;
+    private List<Section> secondaries;
+
+    public Course getCourse() {
+        return this.course;
+    }
+
+    public List<Section> getSecondaries() {
+        return this.secondaries;
+    }
+
+    public CourseOffering()  {
+        secondaries = new ArrayList<Section>();
+    }
+
+    private static Logger logger = LoggerFactory.getLogger(CourseOffering.class);
+ 
+    public String getQuarter() {
+        return course.getQuarter();
+    }
+
+    public String getCourseId() {
+        return course.getCourseId();
+    }
+
+    public String getTitle() {
+        return course.getTitle();
+    }
+
+    /**
+     * Return the name of the main instructor(s) for the course, i.e. the lecture
+     * (primary) section. If there is more than one, they are separated by commas
+     * and a single space.
+     * 
+     * @return Name of primary instructor(s) for the course
+     */
+
+    public String getInstructorList() {
+        if (primary == null)
+            return "";
+        
+        List<Instructor> instructors = primary.getInstructors();
+        if ( (instructors== null ) || (instructors.size() == 0) )
+            return "";
+        List<String> instructorNames = instructors.stream().map((i) -> i.instructor).collect(Collectors.toList());
+        String instructorsCommaSeparated = String.join(", ", instructorNames);
+        return instructorsCommaSeparated;
+    }
+
+    /**
+     * get quarter in Qyy format, e.g. "F19", "W20", etc. instead of "20194" or
+     * "20201"
+     * 
+     * @return quarter in Qyy format (e.g. "F19")
+     */
+
+    public String getQuarterQyy() {
+        String quarter = this.course.getQuarter();
+        try {
+            Quarter q = new Quarter(this.course.getQuarter());
+            return q.toString();
+        } catch (Exception e) {
+            String msg = String.format("Error converting quarter \"%s\": ", quarter);
+            logger.error(msg,e);
+            return "";
+        }
+    }
+
+    /**
+     * Convert a CoursePage object, which is the result of a single call to the JSON API,
+     * into a list of CourseOffering objects.  The main purpose is to group the secondaries (sections)
+     * with the appropriate primaries to make it easier to process, understand, and format the results.
+     */ 
+    public static List<CourseOffering> fromCoursePage(CoursePage cp) {  
+        ArrayList<CourseOffering> result = new ArrayList<CourseOffering>();
+        for ( Course c : cp.getClasses() ) {
+            // Use first two characters of section to group primary with section
+            // Assumption: If last two chars are "00" it's the primary
+            //   otherwise it's a seciton that goes with a matching primary
+
+            HashMap<String, CourseOffering> primaries = new HashMap<String, CourseOffering>();
+            
+            for ( Section s: c.getClassSections() ) {
+                String section = s.getSection();
+                String prefix = section.substring(0,3);
+                String suffix = section.substring(2,4);
+                if (suffix.equals("00")) {
+                    CourseOffering co = new CourseOffering();
+                    co.primary = s;
+                    co.course = c;
+                    primaries.put(prefix,co);
+                } else {
+                    CourseOffering primary = primaries.get(prefix);
+                    if (primary==null) {
+                        logger.error("Could not find primary for prefix " + prefix);
+                        logger.error("primaries = " + primaries);
+                    } else {
+                        logger.info("Adding secondary " + section + " to primary " + primary);
+                        primary.secondaries.add(s);
+                        logger.info("primaries=" + primaries);
+                    }
+                }
+            }
+            result.addAll(primaries.values());
+        }
+        return result;
+    }
+
+
+    @Override
+    public String toString() {
+        return "{" +
+           course.getCourseId() + 
+            "}";
+    }
+
+
+}

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/searches/SearchByDept.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/searches/SearchByDept.java
@@ -1,0 +1,72 @@
+package edu.ucsb.cs56.ucsb_courses_search.searches;
+
+import java.util.Objects;
+
+public class SearchByDept {
+
+    private String dept;
+    private String quarter;
+    private String courseLevel;
+
+    public SearchByDept() {}
+
+    public SearchByDept(String dept, String quarter, String courseLevel) {
+        this.dept = dept;
+        this.quarter = quarter;
+        this.courseLevel = courseLevel;
+    }
+
+    public String getDept() {
+        return this.dept;
+    }
+
+    public void setDept(String dept) {
+        this.dept = dept;
+    }
+
+    public String getQuarter() {
+        return this.quarter;
+    }
+
+    public void setQuarter(String quarter) {
+        this.quarter = quarter;
+    }
+
+    public String getCourseLevel() {
+        return this.courseLevel;
+    }
+
+    public void setCourseLevel(String courseLevel) {
+        this.courseLevel = courseLevel;
+    }
+
+  
+    @Override
+    public boolean equals(Object o) {
+        if (o == this)
+            return true;
+        if (!(o instanceof SearchByDept)) {
+            return false;
+        }
+        SearchByDept searchByDept = (SearchByDept) o;
+        return Objects.equals(dept, searchByDept.dept) && Objects.equals(quarter, searchByDept.quarter) && Objects.equals(courseLevel, searchByDept.courseLevel);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(dept, quarter, courseLevel);
+    }
+
+    @Override
+    public String toString() {
+        return "{" +
+            " dept='" + getDept() + "'" +
+            ", quarter='" + getQuarter() + "'" +
+            ", courseLevel='" + getCourseLevel() + "'" +
+            "}";
+    }
+
+   
+  
+
+} 

--- a/src/main/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/v1/classes/CoursePage.java
+++ b/src/main/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/v1/classes/CoursePage.java
@@ -1,12 +1,12 @@
 package edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes;
 
 import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
-import lombok.Data;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
  * 
  */
 
-@Data
+
 public class CoursePage {
 
     private static Logger logger = LoggerFactory.getLogger(CoursePage.class);
@@ -27,7 +27,7 @@ public class CoursePage {
     public int pageSize;
     public int total;
     public List<Course> classes;
-
+   
     /**
      * Create a CoursePage object from json representation
      * 
@@ -49,4 +49,65 @@ public class CoursePage {
         }
         
     }
+
+    public int getPageNumber() {
+        return this.pageNumber;
+    }
+
+    public void setPageNumber(int pageNumber) {
+        this.pageNumber = pageNumber;
+    }
+
+    public int getPageSize() {
+        return this.pageSize;
+    }
+
+    public void setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+    }
+
+    public int getTotal() {
+        return this.total;
+    }
+
+    public void setTotal(int total) {
+        this.total = total;
+    }
+
+    public List<Course> getClasses() {
+        return this.classes;
+    }
+
+    public void setClasses(List<Course> classes) {
+        this.classes = classes;
+    }
+
+
+    @Override
+    public String toString() {
+        return "{" +
+            " pageNumber='" + getPageNumber() + "'" +
+            ", pageSize='" + getPageSize() + "'" +
+            ", total='" + getTotal() + "'" +
+            ", classes='" + getClasses() + "'" +
+            "}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this)
+            return true;
+        if (!(o instanceof CoursePage)) {
+            return false;
+        }
+        CoursePage coursePage = (CoursePage) o;
+        return pageNumber == coursePage.pageNumber && pageSize == coursePage.pageSize && total == coursePage.total && Objects.equals(classes, coursePage.classes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pageNumber, pageSize, total, classes);
+    }
+
+
 }

--- a/src/main/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/v1/classes/Section.java
+++ b/src/main/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/v1/classes/Section.java
@@ -2,10 +2,175 @@ package edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes;
 
 import java.util.List;
 
-import lombok.Data;
-
-@Data
 public class Section {
+
+
+    /** a unique number assigned to a section */
+    public String getEnrollCode() {
+        return this.enrollCode;
+    }
+
+    /** a unique number assigned to a section */
+    public void setEnrollCode(String enrollCode) {
+        this.enrollCode = enrollCode;
+    }
+
+    /** section number of the course */
+    public String getSection() {
+        return this.section;
+    }
+
+    /** section number of the course */
+    public void setSection(String section) {
+        this.section = section;
+    }
+
+    /** session only for summer quarter */
+    public String getSession() {
+        return this.session;
+    }
+
+    /** session only for summer quarter */
+    public void setSession(String session) {
+        this.session = session;
+    }
+
+    public String getClassClosed() {
+        return this.classClosed;
+    }
+
+    public void setClassClosed(String classClosed) {
+        this.classClosed = classClosed;
+    }
+
+    public String getCourseCancelled() {
+        return this.courseCancelled;
+    }
+
+    public void setCourseCancelled(String courseCancelled) {
+        this.courseCancelled = courseCancelled;
+    }
+
+    public String getGradingOptionCode() {
+        return this.gradingOptionCode;
+    }
+
+    public void setGradingOptionCode(String gradingOptionCode) {
+        this.gradingOptionCode = gradingOptionCode;
+    }
+
+    public int getEnrolledTotal() {
+        return this.enrolledTotal;
+    }
+
+    public void setEnrolledTotal(int enrolledTotal) {
+        this.enrolledTotal = enrolledTotal;
+    }
+
+    public int getMaxEnroll() {
+        return this.maxEnroll;
+    }
+
+    public void setMaxEnroll(int maxEnroll) {
+        this.maxEnroll = maxEnroll;
+    }
+
+    public String getSecondaryStatus() {
+        return this.secondaryStatus;
+    }
+
+    public void setSecondaryStatus(String secondaryStatus) {
+        this.secondaryStatus = secondaryStatus;
+    }
+
+    public boolean isDepartmentApprovalRequired() {
+        return this.departmentApprovalRequired;
+    }
+
+    public boolean getDepartmentApprovalRequired() {
+        return this.departmentApprovalRequired;
+    }
+
+    public void setDepartmentApprovalRequired(boolean departmentApprovalRequired) {
+        this.departmentApprovalRequired = departmentApprovalRequired;
+    }
+
+    public boolean isInstructorApprovalRequired() {
+        return this.instructorApprovalRequired;
+    }
+
+    public boolean getInstructorApprovalRequired() {
+        return this.instructorApprovalRequired;
+    }
+
+    public void setInstructorApprovalRequired(boolean instructorApprovalRequired) {
+        this.instructorApprovalRequired = instructorApprovalRequired;
+    }
+
+    public String getRestrictionLevel() {
+        return this.restrictionLevel;
+    }
+
+    public void setRestrictionLevel(String restrictionLevel) {
+        this.restrictionLevel = restrictionLevel;
+    }
+
+    public String getRestrictionMajor() {
+        return this.restrictionMajor;
+    }
+
+    public void setRestrictionMajor(String restrictionMajor) {
+        this.restrictionMajor = restrictionMajor;
+    }
+
+    public String getRestrictionMajorPass() {
+        return this.restrictionMajorPass;
+    }
+
+    public void setRestrictionMajorPass(String restrictionMajorPass) {
+        this.restrictionMajorPass = restrictionMajorPass;
+    }
+
+    public String getRestrictionMinor() {
+        return this.restrictionMinor;
+    }
+
+    public void setRestrictionMinor(String restrictionMinor) {
+        this.restrictionMinor = restrictionMinor;
+    }
+
+    public String getRestrictionMinorPass() {
+        return this.restrictionMinorPass;
+    }
+
+    public void setRestrictionMinorPass(String restrictionMinorPass) {
+        this.restrictionMinorPass = restrictionMinorPass;
+    }
+
+    public List<String> getConcurrentCourses() {
+        return this.concurrentCourses;
+    }
+
+    public void setConcurrentCourses(List<String> concurrentCourses) {
+        this.concurrentCourses = concurrentCourses;
+    }
+
+    public List<TimeLocation> getTimeLocations() {
+        return this.timeLocations;
+    }
+
+    public void setTimeLocations(List<TimeLocation> timeLocations) {
+        this.timeLocations = timeLocations;
+    }
+
+    public List<Instructor> getInstructors() {
+        return this.instructors;
+    }
+
+    public void setInstructors(List<Instructor> instructors) {
+        this.instructors = instructors;
+    }
+
     /** a unique number assigned to a section */
     public String enrollCode;
     /** section number of the course */
@@ -72,5 +237,30 @@ public class Section {
 
     public boolean isSection(){
         return (Integer.parseInt(this.section) % 100 != 0);
+    }
+
+    @Override
+    public String toString() {
+        return "{" +
+            " enrollCode='" + getEnrollCode() + "'" +
+            ", section='" + getSection() + "'" +
+            ", session='" + getSession() + "'" +
+            ", classClosed='" + getClassClosed() + "'" +
+            ", courseCancelled='" + getCourseCancelled() + "'" +
+            ", gradingOptionCode='" + getGradingOptionCode() + "'" +
+            ", enrolledTotal='" + getEnrolledTotal() + "'" +
+            ", maxEnroll='" + getMaxEnroll() + "'" +
+            ", secondaryStatus='" + getSecondaryStatus() + "'" +
+            ", departmentApprovalRequired='" + isDepartmentApprovalRequired() + "'" +
+            ", instructorApprovalRequired='" + isInstructorApprovalRequired() + "'" +
+            ", restrictionLevel='" + getRestrictionLevel() + "'" +
+            ", restrictionMajor='" + getRestrictionMajor() + "'" +
+            ", restrictionMajorPass='" + getRestrictionMajorPass() + "'" +
+            ", restrictionMinor='" + getRestrictionMinor() + "'" +
+            ", restrictionMinorPass='" + getRestrictionMinorPass() + "'" +
+            ", concurrentCourses='" + getConcurrentCourses() + "'" +
+            ", timeLocations='" + getTimeLocations() + "'" +
+            ", instructors='" + getInstructors() + "'" +
+            "}";
     }
 }

--- a/src/main/resources/templates/fragments/bootstrap_nav_header.html
+++ b/src/main/resources/templates/fragments/bootstrap_nav_header.html
@@ -10,8 +10,8 @@
   <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
     <ul class="navbar-nav mr-auto">
         <li class="nav-item ">
-            <a class="nav-link" href="/" id="navbarDropdown" role="button">
-              Basic Search
+            <a class="nav-link" href="/search/bydept" id="navbarDropdown" role="button">
+              Search By Dept
             </a>
           </li>
       <li class="nav-item dropdown">

--- a/src/main/resources/templates/search/bycourse/fragments/title.html
+++ b/src/main/resources/templates/search/bycourse/fragments/title.html
@@ -1,0 +1,2 @@
+<h1>Search By Course Number</h1>
+<p>This page allows you to search for a given course over multiple quarters.</p>

--- a/src/main/resources/templates/search/bycourse/results.html
+++ b/src/main/resources/templates/search/bycourse/results.html
@@ -2,17 +2,18 @@
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
 
 <head>
-  <title>Course Search Results</title>
+  <title>Search By Course Number</title>
   <div th:replace="fragments/bootstrap_head.html"></div>
 </head>
 
 <body>
   <div class="container">
     <div th:replace="fragments/bootstrap_nav_header.html"></div>
-    <h1>Course Search</h1>
-    <p>This page allows you to search for a given course over multiple quarters.</p>
+
+    <div th:replace="search/bycourse/fragments/title.html"></div>
     <div th:replace="search/bycourse/fragments/form.html"></div>
     <div th:replace="search/bycourse/fragments/list.html"></div>
+
     <div th:replace="fragments/bootstrap_footer.html"></div>
   </div>
   <div th:replace="fragments/bootstrap_scripts.html"></div>

--- a/src/main/resources/templates/search/bydept/fragments/form.html
+++ b/src/main/resources/templates/search/bydept/fragments/form.html
@@ -1,0 +1,139 @@
+<form method="GET"  th:object="${searchByDept}">
+        <div class="form-group row">
+            <label for="dept" class="col-sm-2 col-form-label">Department</label>
+            <div class="col-sm-10">
+                <select th:field="*{dept}" class="custom-select">
+                    <option value="CMPSC">Computer Science - CMPSC</option>
+                    <option value="ANTH">Anthropology - ANTH</option>
+                    <option value="ART">Art - ART</option>
+                    <option value="ART  CS ">Art (Creative Studies) - ART CS </option>
+                    <option value="ARTHI">Art History - ARTHI</option>
+                    <option value="ARTST">Art Studio - ARTST</option>
+                    <option value="AS AM">Asian American Studies - AS AM</option>
+                    <option value="ASTRO">Astronomy - ASTRO</option>
+                    <option value="BIOL">Biology - BIOL</option>
+                    <option value="BIOL CS ">Biology (Creative Studies) - BIOL CS </option>
+                    <option value="BMSE">Biomolecular Science and Engineering - BMSE</option>
+                    <option value="BL ST">Black Studies - BL ST</option>
+                    <option value="CH E">Chemical Engineering - CH E</option>
+                    <option value="CHEM CS ">Chemistry (Creative Studies) - CHEM CS </option>
+                    <option value="CHEM">Chemistry and Biochemistry - CHEM</option>
+                    <option value="CH ST">Chicano Studies - CH ST</option>
+                    <option value="CHIN">Chinese - CHIN</option>
+                    <option value="CLASS">Classics - CLASS</option>
+                    <option value="COMM">Communication - COMM</option>
+                    <option value="C LIT">Comparative Literature - C LIT</option>
+                    <option value="CMPSCCS ">Computer Science (Creative Studies) - CMPSCCS </option>
+                    <option value="CMPTG">Computing (Creative Studies) - CMPTG</option>
+                    <option value="CMPTGCS ">Computing (Creative Studies) - CMPTGCS </option>
+                    <option value="CNCSP">Counseling, Clinical, School Psychology - CNCSP</option>
+                    <option value="DANCE">Dance - DANCE</option>
+                    <option value="DYNS">Dynamical Neuroscience - DYNS</option>
+                    <option value="EARTH">Earth Science - EARTH</option>
+                    <option value="EACS">East Asian Cultural Studies - EACS</option>
+                    <option value="EEMB">Ecology, Evolution &amp; Marine Biology - EEMB</option>
+                    <option value="ECON">Economics - ECON</option>
+                    <option value="ED">Education - ED</option>
+                    <option value="ECE">Electrical Computer Engineering - ECE</option>
+                    <option value="ENGR">Engineering Sciences - ENGR</option>
+                    <option value="ENGL">English - ENGL</option>
+                    <option value="ESM">Environmental Science &amp; Management - ESM</option>
+                    <option value="ENV S">Environmental Studies - ENV S</option>
+                    <option value="ESS">Exercise &amp; Sport Studies - ESS</option>
+                    <option value="ES">Exercise Sport - ES</option>
+                    <option value="FEMST">Feminist Studies - FEMST</option>
+                    <option value="FAMST">Film and Media Studies - FAMST</option>
+                    <option value="FR">French - FR</option>
+                    <option value="GEN S   ">General Studies (Creative Studies) - GEN S </option>
+                    <option value="GEN SCS ">General Studies (Creative Studies) - GEN SCS </option>
+                    <option value="GEOG">Geography - GEOG</option>
+                    <option value="GER">German - GER</option>
+                    <option value="GPS">Global Peace and Security - GPS</option>
+                    <option value="GLOBL">Global Studies - GLOBL</option>
+                    <option value="GRAD">Graduate Division - GRAD</option>
+                    <option value="GREEK">Greek - GREEK</option>
+                    <option value="HEB">Hebrew - HEB</option>
+                    <option value="HIST">History - HIST</option>
+                    <option value="INT">Interdisciplinary - INT</option>
+                    <option value="INT  CS ">Interdisciplinary (Creative Studies) - INT CS </option>
+                    <option value="ITAL">Italian - ITAL</option>
+                    <option value="JAPAN">Japanese - JAPAN</option>
+                    <option value="KOR">Korean - KOR</option>
+                    <option value="LATIN">Latin - LATIN</option>
+                    <option value="LAIS">Latin American and Iberian Studies - LAIS</option>
+                    <option value="LING">Linguistics - LING</option>
+                    <option value="LIT     ">Literature (Creative Studies) - LIT </option>
+                    <option value="LIT  CS ">Literature (Creative Studies) - LIT CS </option>
+                    <option value="MARSC">Marine Science - MARSC</option>
+                    <option value="MATRL">Materials - MATRL</option>
+                    <option value="MATH">Mathematics - MATH</option>
+                    <option value="MATH CS ">Mathematics (Creative Studies) - MATH CS </option>
+                    <option value="ME">Mechanical Engineering - ME</option>
+                    <option value="MAT">Media Arts and Technology - MAT</option>
+                    <option value="ME ST">Medieval Studies - ME ST</option>
+                    <option value="MES">Middle East Studies - MES</option>
+                    <option value="MS">Military Science - MS</option>
+                    <option value="MCDB">Molecular, Cellular &amp; Develop. Biology - MCDB</option>
+                    <option value="MUS">Music - MUS</option>
+                    <option value="MUS  CS ">Music (Creative Studies) - MUS CS </option>
+                    <option value="MUS A">Music Performance Laboratories - MUS A</option>
+                    <option value="PHIL">Philosophy - PHIL</option>
+                    <option value="PHYS">Physics - PHYS</option>
+                    <option value="PHYS CS ">Physics (Creative Studies) - PHYS CS </option>
+                    <option value="POL S">Political Science - POL S</option>
+                    <option value="PORT">Portuguese - PORT</option>
+                    <option value="PSY">Psychology - PSY</option>
+                    <option value="RG ST">Religious Studies - RG ST</option>
+                    <option value="RENST">Renaissance Studies - RENST</option>
+                    <option value="RUSS">Russian - RUSS</option>
+                    <option value="SLAV">Slavic - SLAV</option>
+                    <option value="SOC">Sociology - SOC</option>
+                    <option value="SPAN">Spanish - SPAN</option>
+                    <option value="SHS">Speech &amp; Hearing Sciences - SHS</option>
+                    <option value="PSTAT">Statistics &amp; Applied Probability - PSTAT</option>
+                    <option value="TMP">Technology Management - TMP</option>
+                    <option value="THTR">Theater - THTR</option>
+                    <option value="WRIT">Writing - WRIT</option>
+                    <option value="W&amp;L">Writing &amp; Literature (Creative Studies) - W&amp;L</option>
+                    <option value="W&amp;L  CS ">Writing &amp; Literature (Creative Studies) - W&amp;L CS </option>
+                </select>
+            </div>
+        </div>
+        <div class="form-group row">
+            <label for="quarter" class="col-sm-2 col-form-label">Quarter</label>
+            <div class="col-sm-10">
+                <select th:field="*{quarter}" class="custom-select">
+                    <option selected="selected" value="20201">WINTER 2020</option>
+                    <option selected="selected" value="20194">FALL 2019 </option>
+                    <option value="20193">SUMMER 2019 </option>
+                    <option value="20192">SPRING 2019 </option>
+                    <option value="20191">WINTER 2019 </option>
+                    <option value="20184">FALL 2018 </option>
+                    <option value="20183">SUMMER 2018 </option>
+                    <option value="20182">SPRING 2018 </option>
+                    <option value="20181">WINTER 2018 </option>
+                    <option value="20174">FALL 2017 </option>
+                </select>
+            </div>
+        </div>
+        <div class="form-group row">
+            <label for="courseLevel" class="col-sm-2 col-form-label">Course Level</label>
+            <div class="col-sm-10">
+                <select th:field="*{courseLevel}"class="custom-select">
+                    <option value="L">Undergrad-Lower Division</option>
+                    <option value="S">Undergrad-Upper Division</option>
+                    <option selected="selected" value="U">Undergrad-All</option>
+                    <option value="G">Graduate</option>
+                    <option value="A">All</option>
+                </select>
+            </div>
+        </div>
+        <div class="form-group row">
+            <label for="js-course-search-submit" class="col-sm-2 col-form-label"></label>
+            <div class="col-sm-10">
+                <button type="submit" th:formaction="@{/search/bydept/results}" class="btn btn-primary" id="js-course-search-submit">Find Courses</button>
+            </div>
+        </div>
+    
+        
+    </form>

--- a/src/main/resources/templates/search/bydept/fragments/list.html
+++ b/src/main/resources/templates/search/bydept/fragments/list.html
@@ -1,97 +1,109 @@
+<h2>New List of Courses</h2>
+
+
+
 <table class="table">
-        <thead>
-          <tr>
-            <th>Page Number</th>
-            <th>Page Size</th>
-            <th>Total</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td th:text="${cp.pageNumber}"></td>
-            <td th:text="${cp.pageSize}"></td>
-            <td th:text="${cp.total}"></td>
-          </tr>
-        </tbody>
-      </table>
-  
-      <h2>Courses</h2>
-  
-      <div th:each="c: ${cp.classes}">
-        <table class="table table-bordered">
-          <thead>
-            <tr>
-              <th>Quarter</th>
-              <th>Course Id</th>
-              <th>Title</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td th:text="${c.quarter}" />
-              <td th:text="${c.courseId}" />
-              <td th:text="${c.title}" />
-            </tr>
-          </tbody>
-        </table>
-  
-        <table class="table table-bordered" style="margin-left: 3em; font-size: 80%">
-          <thead>
-            <tr>
-              <th>Enroll Code</th>
-              <th>Enrolled</th>
-              <th>Max</th>
-              <th>Instructor(s)</th>
-              <th>Time and Location</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr th:each="s: ${c.classSections}">
-              <td th:text="${s.enrollCode}" />
-              <td th:text="${s.enrolledTotal}" />
-              <td th:text="${s.maxEnroll}" />
-              <td>
-                <div th:each="i: ${s.instructors}">
-                  <span th:text="${i.instructor}"></span>
-                </div>
-              </td>
-              <td>
-                <div th:each="tl: ${s.timeLocations}">
-                  <table>
-                    <tr>
-                      <td>
-                        <span th:text=${tl.days}></span>
-                        <span th:text=${tl.beginTime}></span>&ndash;<span th:text=${tl.endTime}></span>
-                      </td>
-                      <td>
-                        <span th:text=${tl.building}></span>
-                        <span th:text=${tl.room}></span>
-                      </td>
-                      <!-- th:if to only have the add and drop by sections, not lectures -->
-                      <td th:if="${s.isSection() && isLoggedIn}">
-                         <form action="#" th:action="@{/courseschedule/add}" th:object="${c}" method="post">
-                          <!-- name attributes below are for the th:object which is an instance of 
+  <thead>
+    <tr>
+      <th>Quarter</th>
+      <th>Course Id</th>
+      <th>Title</th>
+      <th>Num Sections</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr th:each="co: ${courseOfferings}">
+      <td th:text="${co.course.getQuarterQyy()}"></td>
+      <td th:text="${co.course.courseId}"></td>
+      <td th:text="${co.course.title}"></td>
+      <td th:text="${co.secondaries.size()}"></td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>Courses</h2>
+
+<div th:each="c: ${cp.classes}">
+  <table class="table table-bordered">
+    <thead>
+      <tr>
+        <th>Quarter</th>
+        <th>Course Id</th>
+        <th>Title</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td th:text="${c.quarter}" />
+        <td th:text="${c.courseId}" />
+        <td th:text="${c.title}" />
+      </tr>
+    </tbody>
+  </table>
+
+  <table class="table table-bordered" style="margin-left: 3em; font-size: 80%">
+    <thead>
+      <tr>
+        <th>Enroll Code</th>
+        <th>Section</th>
+        <th>Secondary Status</th>
+        <th>Enrolled</th>
+        <th>Max</th>
+        <th>Instructor(s)</th>
+        <th>Time and Location</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr th:each="s: ${c.classSections}">
+        <td th:text="${s.enrollCode}" />
+        <td th:text="${s.section}" />
+        <td th:text="${s.secondaryStatus}" />
+        <td th:text="${s.enrolledTotal}" />
+        <td th:text="${s.maxEnroll}" />
+        <td>
+          <div th:each="i: ${s.instructors}">
+            <span th:text="${i.instructor}"></span>
+          </div>
+        </td>
+        <td>
+          <div th:each="tl: ${s.timeLocations}">
+            <table>
+              <tr>
+                <td>
+                  <span th:text=${tl.days}></span>
+                  <span th:text=${tl.beginTime}></span>&ndash;<span th:text=${tl.endTime}></span>
+                </td>
+                <td>
+                  <span th:text=${tl.building}></span>
+                  <span th:text=${tl.room}></span>
+                </td>
+                <!-- th:if to only have the add and drop by sections, not lectures -->
+                <td th:if="${s.isSection() && isLoggedIn}">
+                  <form action="#" th:action="@{/courseschedule/add}" th:object="${c}" method="post">
+                    <!-- name attributes below are for the th:object which is an instance of 
                                the @Entity that is a parameter of the controller endpoint for 
                                the th:action above.  th:value values are computed based on the
                                objects being iterated over passed into this view -->
-                          <input type="hidden" name="classname" th:value="${c.courseId} "value="" />
-                          <input type="hidden" name="enrollCode" th:value="${s.enrollCode} "value="" />
-                          <input type="hidden" name="uid" th:value="${id}" value="1000" />  
-                          <input type="hidden" name="professor" th:value="${c.mainInstructorList()}" value="" />
-                          <input type="hidden" name="meettime"  th:value="${s.timeLocations[0].beginTime + '-' + s.timeLocations[0].endTime}" value="" />
-                          <input type="hidden" name="meetday" th:value="${s.timeLocations[0].days}" value="" />
-                          <input type="hidden" name="location" th:value="${s.timeLocations[0].building + '-' + s.timeLocations[0].room}" value="" /> 
-                          <input type="hidden" name="quarter" th:value="${c.getQuarterQyy()}" value="" /> 
-                          <input type="submit" class="btn btn-primary" value="Add" />  
-                        </form> 
-                        
-                    </tr>
-                  </table>
-  
-                </div>
-  
-              </td>
-  
-            </tr>
-          </tbody>
-        </table>
+                    <input type="hidden" name="classname" th:value="${c.courseId} " value="" />
+                    <input type="hidden" name="enrollCode" th:value="${s.enrollCode} " value="" />
+                    <input type="hidden" name="uid" th:value="${id}" value="1000" />
+                    <input type="hidden" name="professor" th:value="${c.mainInstructorList()}" value="" />
+                    <input type="hidden" name="meettime"
+                      th:value="${s.timeLocations[0].beginTime + '-' + s.timeLocations[0].endTime}" value="" />
+                    <input type="hidden" name="meetday" th:value="${s.timeLocations[0].days}" value="" />
+                    <input type="hidden" name="location"
+                      th:value="${s.timeLocations[0].building + '-' + s.timeLocations[0].room}" value="" />
+                    <input type="hidden" name="quarter" th:value="${c.getQuarterQyy()}" value="" />
+                    <input type="submit" class="btn btn-primary" value="Add" />
+                  </form>
+
+              </tr>
+            </table>
+
+          </div>
+
+        </td>
+
+      </tr>
+    </tbody>
+  </table>

--- a/src/main/resources/templates/search/bydept/fragments/list.html
+++ b/src/main/resources/templates/search/bydept/fragments/list.html
@@ -1,0 +1,97 @@
+<table class="table">
+        <thead>
+          <tr>
+            <th>Page Number</th>
+            <th>Page Size</th>
+            <th>Total</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td th:text="${cp.pageNumber}"></td>
+            <td th:text="${cp.pageSize}"></td>
+            <td th:text="${cp.total}"></td>
+          </tr>
+        </tbody>
+      </table>
+  
+      <h2>Courses</h2>
+  
+      <div th:each="c: ${cp.classes}">
+        <table class="table table-bordered">
+          <thead>
+            <tr>
+              <th>Quarter</th>
+              <th>Course Id</th>
+              <th>Title</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td th:text="${c.quarter}" />
+              <td th:text="${c.courseId}" />
+              <td th:text="${c.title}" />
+            </tr>
+          </tbody>
+        </table>
+  
+        <table class="table table-bordered" style="margin-left: 3em; font-size: 80%">
+          <thead>
+            <tr>
+              <th>Enroll Code</th>
+              <th>Enrolled</th>
+              <th>Max</th>
+              <th>Instructor(s)</th>
+              <th>Time and Location</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr th:each="s: ${c.classSections}">
+              <td th:text="${s.enrollCode}" />
+              <td th:text="${s.enrolledTotal}" />
+              <td th:text="${s.maxEnroll}" />
+              <td>
+                <div th:each="i: ${s.instructors}">
+                  <span th:text="${i.instructor}"></span>
+                </div>
+              </td>
+              <td>
+                <div th:each="tl: ${s.timeLocations}">
+                  <table>
+                    <tr>
+                      <td>
+                        <span th:text=${tl.days}></span>
+                        <span th:text=${tl.beginTime}></span>&ndash;<span th:text=${tl.endTime}></span>
+                      </td>
+                      <td>
+                        <span th:text=${tl.building}></span>
+                        <span th:text=${tl.room}></span>
+                      </td>
+                      <!-- th:if to only have the add and drop by sections, not lectures -->
+                      <td th:if="${s.isSection() && isLoggedIn}">
+                         <form action="#" th:action="@{/courseschedule/add}" th:object="${c}" method="post">
+                          <!-- name attributes below are for the th:object which is an instance of 
+                               the @Entity that is a parameter of the controller endpoint for 
+                               the th:action above.  th:value values are computed based on the
+                               objects being iterated over passed into this view -->
+                          <input type="hidden" name="classname" th:value="${c.courseId} "value="" />
+                          <input type="hidden" name="enrollCode" th:value="${s.enrollCode} "value="" />
+                          <input type="hidden" name="uid" th:value="${id}" value="1000" />  
+                          <input type="hidden" name="professor" th:value="${c.mainInstructorList()}" value="" />
+                          <input type="hidden" name="meettime"  th:value="${s.timeLocations[0].beginTime + '-' + s.timeLocations[0].endTime}" value="" />
+                          <input type="hidden" name="meetday" th:value="${s.timeLocations[0].days}" value="" />
+                          <input type="hidden" name="location" th:value="${s.timeLocations[0].building + '-' + s.timeLocations[0].room}" value="" /> 
+                          <input type="hidden" name="quarter" th:value="${c.getQuarterQyy()}" value="" /> 
+                          <input type="submit" class="btn btn-primary" value="Add" />  
+                        </form> 
+                        
+                    </tr>
+                  </table>
+  
+                </div>
+  
+              </td>
+  
+            </tr>
+          </tbody>
+        </table>

--- a/src/main/resources/templates/search/bydept/fragments/title.html
+++ b/src/main/resources/templates/search/bydept/fragments/title.html
@@ -1,0 +1,4 @@
+<h1>Search By Dept</h1>
+<p>This page allows you to search for all courses offered by a particular department in a specific quarter,
+    at a specific course level.
+</p>

--- a/src/main/resources/templates/search/bydept/results.html
+++ b/src/main/resources/templates/search/bydept/results.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
 
 <head>
-  <title>Search By Course Number</title>
+  <title>Search By Department</title>
   <div th:replace="fragments/bootstrap_head.html"></div>
 </head>
 
@@ -10,8 +10,9 @@
   <div class="container">
     <div th:replace="fragments/bootstrap_nav_header.html"></div>
 
-    <div th:replace="search/bycourse/fragments/title.html"></div>
-    <div th:replace="search/bycourse/fragments/form.html"></div>
+    <div th:replace="search/bydept/fragments/title.html"></div>
+    <div th:replace="search/bydept/fragments/form.html"></div>
+    <div th:replace="search/bydept/fragments/list.html"></div>
 
     <div th:replace="fragments/bootstrap_footer.html"></div>
   </div>

--- a/src/main/resources/templates/search/bydept/search.html
+++ b/src/main/resources/templates/search/bydept/search.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
 
 <head>
-  <title>Search By Course Number</title>
+  <title>Search By Department</title>
   <div th:replace="fragments/bootstrap_head.html"></div>
 </head>
 
@@ -10,8 +10,8 @@
   <div class="container">
     <div th:replace="fragments/bootstrap_nav_header.html"></div>
 
-    <div th:replace="search/bycourse/fragments/title.html"></div>
-    <div th:replace="search/bycourse/fragments/form.html"></div>
+    <div th:replace="search/bydept/fragments/title.html"></div>
+    <div th:replace="search/bydept/fragments/form.html"></div>
 
     <div th:replace="fragments/bootstrap_footer.html"></div>
   </div>


### PR DESCRIPTION
In this PR, we:

* Make it possible to search all levels "A" (grad and undergrad) by adding that feature to the
  search service (to make this work in the API, you just don't pass anything for that parameter)
* Unprotect (don't require login) for all endpoints that start with `search/` (will eventually 
  refactor so that all searches that don't update state are under that URL pattern)
* Add a search by department that will eventually replace the basic search, and has 
   an improved format for results returned.