### PR TITLE
pc - reorganize nav bar

### DIFF
--- a/src/main/resources/templates/fragments/bootstrap_nav_header.html
+++ b/src/main/resources/templates/fragments/bootstrap_nav_header.html
@@ -9,15 +9,17 @@
   </button>
   <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
     <ul class="navbar-nav mr-auto">
-        <li class="nav-item ">
-            <a class="nav-link" href="/search/bydept" id="navbarDropdown" role="button">
-              Search By Dept
-            </a>
-          </li>
+    
+      <li class="nav-item ">
+        <a class="nav-link" href="/search/bydept" id="navbarDropdown" role="button">
+          By Dept
+        </a>
+      </li>
+    
       <li class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown"
           aria-haspopup="true" aria-expanded="false">
-          Search by Instructor
+          By Instructor
         </a>
         <div class="dropdown-menu" aria-labelledby="navbarDropdown">
           <a class="dropdown-item" href="/instructor/search">Basic Instructor Search</a>
@@ -25,6 +27,13 @@
           <a class="dropdown-item" href="/instructor/multi">Multiquarter Instructor Search</a>
         </div>
       </li>
+    
+      <li class="nav-item ">
+        <a class="nav-link" href="/search/bycourse" id="navbarDropdown" role="button">
+          By Course
+        </a>
+      </li>
+
       <li class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown"
           aria-haspopup="true" aria-expanded="false">
@@ -34,15 +43,7 @@
           <a class="dropdown-item" href="/courseschedule">See Your Schedule</a>
         </div>
       </li>
-      <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown"
-          aria-haspopup="true" aria-expanded="false">
-          Search by Course
-        </a>
-        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-          <a class="dropdown-item" href="/search/bycourse">Search by Course</a>
-        </div>
-      </li>
+
       <!-- Copy/paste this template when adding additional menu items -->
       <!--
               <li class="nav-item dropdown">


### PR DESCRIPTION
In this PR, we reorganize the nav bar so that basic searches (that don't require login) are all together on the left, and the feature requiring login is at the right.