### PR TITLE
Pc update by dept search

### DIFF
--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/SearchByDeptController.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/SearchByDeptController.java
@@ -7,12 +7,12 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import edu.ucsb.cs56.ucsb_courses_search.CurriculumService;
+import edu.ucsb.cs56.ucsb_courses_search.results.CourseListingRow;
 import edu.ucsb.cs56.ucsb_courses_search.results.CourseOffering;
 import edu.ucsb.cs56.ucsb_courses_search.searches.SearchByDept;
 import edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes.Course;
 import edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes.CoursePage;
 import edu.ucsb.cs56.ucsbapi.academics.curriculums.utilities.Quarter;
-
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,39 +25,35 @@ public class SearchByDeptController {
 
     private Logger logger = LoggerFactory.getLogger(SearchByDeptController.class);
 
-    @Autowired   
+    @Autowired
     private CurriculumService curriculumService;
 
-    
     @GetMapping("/search/bydept")
     public String instructor(Model model, SearchByDept searchByDept) {
-    	model.addAttribute("searchByDept", new SearchByDept());
-        return "search/bydept/search"; 
+        model.addAttribute("searchByDept", new SearchByDept());
+        return "search/bydept/search";
     }
 
     @GetMapping("/search/bydept/results")
-    public String search(
-        @RequestParam(name = "dept", required = true) 
-        String dept,
-        @RequestParam(name = "quarter", required = true) 
-        String quarter,
-        @RequestParam(name = "courseLevel", required = true) 
-        String courseLevel,
-        Model model, SearchByDept searchByDept
-        ) {
+    public String search(@RequestParam(name = "dept", required = true) String dept,
+            @RequestParam(name = "quarter", required = true) String quarter,
+            @RequestParam(name = "courseLevel", required = true) String courseLevel, Model model,
+            SearchByDept searchByDept) {
         model.addAttribute("dept", dept);
         model.addAttribute("quarter", quarter);
         model.addAttribute("courseLevel", courseLevel);
 
-        String json = curriculumService.getJSON(dept,quarter,courseLevel);
+        String json = curriculumService.getJSON(dept, quarter, courseLevel);
         CoursePage cp = CoursePage.fromJSON(json);
 
         List<CourseOffering> courseOfferings = CourseOffering.fromCoursePage(cp);
-        
-        model.addAttribute("cp",cp);
-        model.addAttribute("courseOfferings",courseOfferings);
 
-        return "search/bydept/results"; 
+        List<CourseListingRow> rows = CourseListingRow.fromCourseOfferings(courseOfferings);
+
+        model.addAttribute("cp", cp);
+        model.addAttribute("rows", rows);
+
+        return "search/bydept/results";
     }
 
 }

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/results/CourseListingRow.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/results/CourseListingRow.java
@@ -1,0 +1,170 @@
+package edu.ucsb.cs56.ucsb_courses_search.results;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.hibernate.type.AbstractStandardBasicType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes.Section;
+import edu.ucsb.cs56.ucsbapi.academics.curriculums.utilities.Quarter;
+import edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes.Course;
+import edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes.CoursePage;
+import edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes.Instructor;
+import edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes.TimeLocation;
+
+public class CourseListingRow {
+
+    public enum RowType {
+        PRIMARY, SECONDARY, ADDITIONAL_TIME_LOCATION
+    }
+
+    private Course course;
+    private RowType rowType;
+    private Section section;
+    private TimeLocation timeLocation;
+    private boolean firstRow;
+    private boolean lastRow;
+
+    public CourseListingRow(Course course, RowType rowType, Section section, TimeLocation timeLocation,
+            boolean firstRow, boolean lastRow) {
+        this.course = course;
+        this.rowType = rowType;
+        this.section = section;
+        this.timeLocation = timeLocation;
+        this.firstRow = firstRow;
+        this.lastRow = lastRow;
+    }
+
+    /**
+     * Convert a CoursePage object, which is the result of a single call to the JSON API,
+     * into a list of CourseOffering objects.  The main purpose is to group the secondaries (sections)
+     * with the appropriate primaries to make it easier to process, understand, and format the results.
+     */ 
+    public static List<CourseListingRow> fromCourseOfferings(List<CourseOffering> courseOfferings) {  
+        ArrayList<CourseListingRow> result = new ArrayList<CourseListingRow>();
+        for ( CourseOffering co : courseOfferings ) {
+            
+            // Add primary to result
+
+            List<TimeLocation> timeLocations = co.getPrimary().getTimeLocations();
+            TimeLocation primaryFirstTimeLocation = 
+                timeLocations.size() == 0 ? null : timeLocations.get(0);
+
+            CourseListingRow primary = new CourseListingRow(
+                co.getCourse(),
+                RowType.PRIMARY,
+                co.getPrimary(),
+                primaryFirstTimeLocation,
+                true,
+                co.getPrimary().getTimeLocations().size() <= 1 &&
+                co.getSecondaries().size() == 0);
+            result.add(primary);
+
+            for (int i=1; i<co.getPrimary().getTimeLocations().size(); i++) {
+                CourseListingRow timeLoc = new CourseListingRow(
+                    co.getCourse(),
+                    RowType.ADDITIONAL_TIME_LOCATION,
+                    co.getPrimary(),
+                    co.getPrimary().getTimeLocations().get(i),
+                    false,
+                    (i == (co.getPrimary().getTimeLocations().size() - 1)) &&
+                    co.getSecondaries().size() == 0);
+                result.add(timeLoc);
+            }
+        
+            List<Section> secondaries = co.getSecondaries();
+            
+            Section last = null;
+            if (secondaries.size() > 0)
+               last = secondaries.get(secondaries.size() - 1);
+
+            for ( Section s: secondaries ) {
+
+                List<TimeLocation> sectionTimeLocations = s.getTimeLocations();
+                TimeLocation sectionFirstTimeLocation = 
+                    sectionTimeLocations.size() == 0 ? null : sectionTimeLocations.get(0);
+    
+
+                CourseListingRow secondary = new CourseListingRow(
+                    co.getCourse(),
+                    RowType.SECONDARY,
+                    s,
+                    sectionFirstTimeLocation,
+                    false,
+                    s == last && co.getPrimary().getTimeLocations().size() <= 1 );
+
+                result.add(secondary);
+
+                for (int i=1; i<s.getTimeLocations().size(); i++) {
+                    CourseListingRow timeLoc = new CourseListingRow(
+                        co.getCourse(),
+                        RowType.ADDITIONAL_TIME_LOCATION,
+                        s,
+                        s.getTimeLocations().get(i),
+                        false,
+                        s == last && 
+                        (i == (co.getPrimary().getTimeLocations().size() - 1)));
+                    result.add(timeLoc);
+                }
+            }      
+        }
+        return result;
+    }
+
+    public Course getCourse() {
+        return this.course;
+    }
+
+    public void setCourse(Course course) {
+        this.course = course;
+    }
+
+    // Need to return ENUM as a String for Thymeleaf == and != against strings
+    public String getRowType() {
+        return this.rowType.toString();
+    }
+
+    public void setRowType(RowType rowType) {
+        this.rowType = rowType;
+    }
+
+    public Section getSection() {
+        return this.section;
+    }
+
+    public void setSection(Section section) {
+        this.section = section;
+    }
+
+    public TimeLocation getTimeLocation() {
+        return this.timeLocation;
+    }
+
+    public void setTimeLocation(TimeLocation timeLocation) {
+        this.timeLocation = timeLocation;
+    }
+
+    public boolean isLastRow() {
+        return this.lastRow;
+    }
+
+    public boolean getFirstRow() {
+        return this.firstRow;
+    }
+
+    public void setFirstRow(boolean firstRow) {
+        this.firstRow = firstRow;
+    }
+
+    public boolean getLastRow() {
+        return this.lastRow;
+    }
+
+    public void setLastRow(boolean lastRow) {
+        this.lastRow = lastRow;
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/results/CourseOffering.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/results/CourseOffering.java
@@ -21,8 +21,13 @@ public class CourseOffering {
     private Section primary;
     private List<Section> secondaries;
 
+
     public Course getCourse() {
         return this.course;
+    }
+
+    public Section getPrimary() {
+        return this.primary;
     }
 
     public List<Section> getSecondaries() {

--- a/src/main/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/v1/classes/Section.java
+++ b/src/main/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/v1/classes/Section.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class Section {
 
@@ -237,6 +238,20 @@ public class Section {
 
     public boolean isSection(){
         return (Integer.parseInt(this.section) % 100 != 0);
+    }
+
+
+  /**
+     * Return the name of the instructor(s) for the section. 
+     * If there is more than one, they are separated by commas
+     * and a single space.
+     * 
+     * @return Name of instructor(s) for the section.
+     */
+    public String instructorList() { 
+        List<String> instructorNames = this.instructors.stream().map((i) -> i.instructor).collect(Collectors.toList());
+        String instructorsCommaSeparated = String.join(", ", instructorNames);
+        return instructorsCommaSeparated;
     }
 
     @Override

--- a/src/main/resources/templates/fragments/bootstrap_nav_header.html
+++ b/src/main/resources/templates/fragments/bootstrap_nav_header.html
@@ -9,15 +9,17 @@
   </button>
   <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
     <ul class="navbar-nav mr-auto">
-        <li class="nav-item ">
-            <a class="nav-link" href="/search/bydept" id="navbarDropdown" role="button">
-              Search By Dept
-            </a>
-          </li>
+    
+      <li class="nav-item ">
+        <a class="nav-link" href="/search/bydept" id="navbarDropdown" role="button">
+          By Dept
+        </a>
+      </li>
+    
       <li class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown"
           aria-haspopup="true" aria-expanded="false">
-          Search by Instructor
+          By Instructor
         </a>
         <div class="dropdown-menu" aria-labelledby="navbarDropdown">
           <a class="dropdown-item" href="/instructor/search">Basic Instructor Search</a>
@@ -25,6 +27,13 @@
           <a class="dropdown-item" href="/instructor/multi">Multiquarter Instructor Search</a>
         </div>
       </li>
+    
+      <li class="nav-item ">
+        <a class="nav-link" href="/search/bycourse" id="navbarDropdown" role="button">
+          By Course
+        </a>
+      </li>
+
       <li class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown"
           aria-haspopup="true" aria-expanded="false">
@@ -34,15 +43,7 @@
           <a class="dropdown-item" href="/courseschedule">See Your Schedule</a>
         </div>
       </li>
-      <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown"
-          aria-haspopup="true" aria-expanded="false">
-          Search by Course
-        </a>
-        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-          <a class="dropdown-item" href="/search/bycourse">Search by Course</a>
-        </div>
-      </li>
+
       <!-- Copy/paste this template when adding additional menu items -->
       <!--
               <li class="nav-item dropdown">

--- a/src/main/resources/templates/search/bydept/fragments/list.html
+++ b/src/main/resources/templates/search/bydept/fragments/list.html
@@ -1,109 +1,42 @@
-<h2>New List of Courses</h2>
+<h2>Courses</h2>
+
+<style>
+  tr.firstRowForCourse { border-top: solid black 2px;}
+  tr.lastRowForCourse { border-bottom: solid black 2px;}
+  tr.SECONDARY td.section { padding-left: 2em; }
+  tr.SECONDARY td.enrollCode { padding-left: 2em; }
+  tr.SECONDARY td.instructorList { padding-left: 2em; }
 
 
+</style>
 
 <table class="table">
   <thead>
     <tr>
-      <th>Quarter</th>
       <th>Course Id</th>
       <th>Title</th>
-      <th>Num Sections</th>
+      <th>Section</th>
+      <th>Instructor</th>
+      <th>Enroll Cd</th>
+      <th>Days</th>
+      <th>Time</th>
+      <th>Location</th>
+      <th>Enrolled</th>
+      <th>Capacity</th>
     </tr>
   </thead>
   <tbody>
-    <tr th:each="co: ${courseOfferings}">
-      <td th:text="${co.course.getQuarterQyy()}"></td>
-      <td th:text="${co.course.courseId}"></td>
-      <td th:text="${co.course.title}"></td>
-      <td th:text="${co.secondaries.size()}"></td>
+    <tr th:each="r: ${rows}" th:class="(${r.firstRow} ? 'firstRowForCourse' : '') + ' ' + (${r.lastRow} ? 'lastRowForCourse' : '') + ' ' + ${r.rowType}" >
+      <td th:text="${r.rowType}=='PRIMARY' ? ${r.course.courseId} : '' "></td>
+      <td th:text="${r.rowType}=='PRIMARY' ? ${r.course.title} : '' "></td>
+      <td class="section" th:text="${r.section.section}"></td>
+      <td class="instructorList" th:text="${r.section.instructorList()}"></td>
+      <td class="enrollCode" th:text="${r.section.enrollCode}"></td>
+      <td th:text="${r.timeLocation?.days}"></td>
+      <td th:text="${r.timeLocation == null} ? '' : ${r.timeLocation?.beginTime}+' - '+${r.timeLocation?.endTime}"></td>
+      <td th:text="${r.timeLocation == null} ? '' : ${r.timeLocation?.building}+' '+${r.timeLocation?.room}"></td>
+      <td th:text="${r.section.enrolledTotal}"></td>
+      <td th:text="${r.section.maxEnroll}"></td>
     </tr>
   </tbody>
 </table>
-
-<h2>Courses</h2>
-
-<div th:each="c: ${cp.classes}">
-  <table class="table table-bordered">
-    <thead>
-      <tr>
-        <th>Quarter</th>
-        <th>Course Id</th>
-        <th>Title</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td th:text="${c.quarter}" />
-        <td th:text="${c.courseId}" />
-        <td th:text="${c.title}" />
-      </tr>
-    </tbody>
-  </table>
-
-  <table class="table table-bordered" style="margin-left: 3em; font-size: 80%">
-    <thead>
-      <tr>
-        <th>Enroll Code</th>
-        <th>Section</th>
-        <th>Secondary Status</th>
-        <th>Enrolled</th>
-        <th>Max</th>
-        <th>Instructor(s)</th>
-        <th>Time and Location</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr th:each="s: ${c.classSections}">
-        <td th:text="${s.enrollCode}" />
-        <td th:text="${s.section}" />
-        <td th:text="${s.secondaryStatus}" />
-        <td th:text="${s.enrolledTotal}" />
-        <td th:text="${s.maxEnroll}" />
-        <td>
-          <div th:each="i: ${s.instructors}">
-            <span th:text="${i.instructor}"></span>
-          </div>
-        </td>
-        <td>
-          <div th:each="tl: ${s.timeLocations}">
-            <table>
-              <tr>
-                <td>
-                  <span th:text=${tl.days}></span>
-                  <span th:text=${tl.beginTime}></span>&ndash;<span th:text=${tl.endTime}></span>
-                </td>
-                <td>
-                  <span th:text=${tl.building}></span>
-                  <span th:text=${tl.room}></span>
-                </td>
-                <!-- th:if to only have the add and drop by sections, not lectures -->
-                <td th:if="${s.isSection() && isLoggedIn}">
-                  <form action="#" th:action="@{/courseschedule/add}" th:object="${c}" method="post">
-                    <!-- name attributes below are for the th:object which is an instance of 
-                               the @Entity that is a parameter of the controller endpoint for 
-                               the th:action above.  th:value values are computed based on the
-                               objects being iterated over passed into this view -->
-                    <input type="hidden" name="classname" th:value="${c.courseId} " value="" />
-                    <input type="hidden" name="enrollCode" th:value="${s.enrollCode} " value="" />
-                    <input type="hidden" name="uid" th:value="${id}" value="1000" />
-                    <input type="hidden" name="professor" th:value="${c.mainInstructorList()}" value="" />
-                    <input type="hidden" name="meettime"
-                      th:value="${s.timeLocations[0].beginTime + '-' + s.timeLocations[0].endTime}" value="" />
-                    <input type="hidden" name="meetday" th:value="${s.timeLocations[0].days}" value="" />
-                    <input type="hidden" name="location"
-                      th:value="${s.timeLocations[0].building + '-' + s.timeLocations[0].room}" value="" />
-                    <input type="hidden" name="quarter" th:value="${c.getQuarterQyy()}" value="" />
-                    <input type="submit" class="btn btn-primary" value="Add" />
-                  </form>
-
-              </tr>
-            </table>
-
-          </div>
-
-        </td>
-
-      </tr>
-    </tbody>
-  </table>


### PR DESCRIPTION
In this PR, we update the "by department search" to have listings that provide a more compact and readable version of the results.

We add enrollment, capacity, section number, enrollment code, indentation for secondaries, and lines to group primary and secondaries together.  

There is also code in place to show multiple timeLocations, but it is as yet untested.