### PR TITLE
pc - add more quarters to by course search

### DIFF
--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/SearchByCourseController.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/SearchByCourseController.java
@@ -31,6 +31,9 @@ public class SearchByCourseController {
 
     @GetMapping("/search/bycourse")
     public String instructor(Model model, SearchByCourse searchByCourse) {
+        List<Quarter> quarters= new ArrayList<Quarter>();
+
+        model.addAttribute("quarters",Quarter.quarterList("W20","F83"));
         model.addAttribute("searchByCourse", new SearchByCourse());
         return "search/bycourse/search";
     }
@@ -61,7 +64,10 @@ public class SearchByCourseController {
 
         model.addAttribute("rows", primaryRows);
 
+        // Note: F83 seems to be the oldest data available in the API
+        model.addAttribute("quarters",Quarter.quarterList("W20","F83"));
         return "search/bycourse/results";
     }
+
 
 }

--- a/src/main/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/utilities/Quarter.java
+++ b/src/main/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/utilities/Quarter.java
@@ -1,5 +1,9 @@
 package edu.ucsb.cs56.ucsbapi.academics.curriculums.utilities;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
 /**
  * Represents a UCSB quarter. Allows easy conversion between QYY alphanumeric
  * format (F19, W20, S20, M20) and YYYYQ numerical format (20194, 20201, 20202,
@@ -26,23 +30,25 @@ public class Quarter {
     }
 
     /**
-     * Construct a Quarter object from a string s, either in QYY or YYYYQ format.
-     * If s is of length three, QYY format is expected, if 5 then YYYYQ format is expected.
-     * Otherwise an IllegalArgumentException is thrown.
+     * Construct a Quarter object from a string s, either in QYY or YYYYQ format. If
+     * s is of length three, QYY format is expected, if 5 then YYYYQ format is
+     * expected. Otherwise an IllegalArgumentException is thrown.
+     * 
      * @param s Quarter either in QYY or YYYYQ format
      */
 
     public Quarter(String s) {
 
-        switch (s.length()) {
-            case 3:
-                this.yyyyq = qyyToQyyyy(s); 
-                return;
-            case 5:
-                this.yyyyq = yyyyqToInt(s);
-                return;
-            default:
-               throw new IllegalArgumentException("Quarter shoudl be in QYY or YYYYQ format");
+        switch (s
+                .length()) {
+        case 3:
+            this.yyyyq = qyyToQyyyy(s);
+            return;
+        case 5:
+            this.yyyyq = yyyyqToInt(s);
+            return;
+        default:
+            throw new IllegalArgumentException("Quarter shoudl be in QYY or YYYYQ format");
         }
     }
 
@@ -55,7 +61,7 @@ public class Quarter {
     }
 
     public String toString() {
-        return  yyyyqToQyy(this.yyyyq);
+        return yyyyqToQyy(this.yyyyq);
     }
 
     public String getQ() {
@@ -68,19 +74,37 @@ public class Quarter {
     }
 
     /**
-     * Advance to the next quater, and return the value of that quarter as an int.
-     * @return the new getValue() for the quarter, i.e. quarter as in in yyyyq format
+     * Advance to the next quarter, and return the value of that quarter as an int.
+     * 
+     * @return the new getValue() for the quarter, i.e. quarter as in in yyyyq
+     *         format
      */
     public int increment() {
         int q = this.yyyyq % 10;
         int yyyy = this.yyyyq / 10;
 
-        setValue( (q==4) ? (((yyyy + 1) * 10) + 1 ) : (this.yyyyq + 1) );
+        setValue((q == 4) ? (((yyyy + 1) * 10) + 1) : (this.yyyyq + 1));
+        return this.yyyyq;
+    }
+
+    /**
+     * Subtract one from current quarter, and return the value of that quarter as an
+     * int.
+     * 
+     * @return the new getValue() for the quarter, i.e. quarter as in in yyyyq
+     *         format
+     */
+    public int decrement() {
+        int q = this.yyyyq % 10;
+        int yyyy = this.yyyyq / 10;
+
+        setValue((q == 1) ? (((yyyy - 1) * 10) + 4) : (this.yyyyq - 1));
         return this.yyyyq;
     }
 
     /**
      * Convert yyyyq as string to int, throwing exception if format is incorrect
+     * 
      * @param yyyyq String in yyyyq format (e.g. 20194 for F19 (Fall 2019))
      * @throws IllegalArgumentException
      * @return int representation of quarter
@@ -89,7 +113,8 @@ public class Quarter {
         String errorMsg = "Argument should be a string representation of a five digit integer yyyyq ending in 1,2,3 or 4";
         int result = 0;
         try {
-            result = Integer.parseInt(yyyyq);
+            result = Integer
+                    .parseInt(yyyyq);
         } catch (Exception e) {
             throw new IllegalArgumentException(errorMsg);
         }
@@ -99,30 +124,36 @@ public class Quarter {
         return result;
     }
 
-     /**
-     * Convert yyyyq int format to Yqq String format throwing exception if format is incorrect
+    /**
+     * Convert yyyyq int format to Yqq String format throwing exception if format is
+     * incorrect
+     * 
      * @param yyyyq int (e.g. 20194 for Fall 2019
      * @throws IllegalArgumentException
      * @return Qyy representation (e.g. F19)
      */
     public static String yyyyqToQyy(int yyyyq) {
         if (invalidQtr(yyyyq)) {
-            throw new IllegalArgumentException("Argument should be a five digit integer in qqqqy format ending in 1,2,3 or 4");
+            throw new IllegalArgumentException(
+                    "Argument should be a five digit integer in qqqqy format ending in 1,2,3 or 4");
         }
-        return String.format("%s%s", getQ(yyyyq), getYY(yyyyq));        
+        return String
+                .format("%s%s", getQ(yyyyq), getYY(yyyyq));
     }
 
-     /**
-     * Take yyyyq int format and return single character for quarter, 
-     * either "W", "S", "M", or "F" for last digit 1, 2, 3, 4, respectively.
-     * Throw illegal argument exception if not in yyyyq format.
+    /**
+     * Take yyyyq int format and return single character for quarter, either "W",
+     * "S", "M", or "F" for last digit 1, 2, 3, 4, respectively. Throw illegal
+     * argument exception if not in yyyyq format.
+     * 
      * @param yyyyq int (e.g. 20194 for Fall 2019)
      * @throws IllegalArgumentException
-     * @return single char string for quarter (e.g. "F") 
+     * @return single char string for quarter (e.g. "F")
      */
     public static String getQ(int yyyyq) {
         if (invalidQtr(yyyyq)) {
-            throw new IllegalArgumentException("Argument should be a five digit integer in qqqqy format ending in 1,2,3 or 4");
+            throw new IllegalArgumentException(
+                    "Argument should be a five digit integer in qqqqy format ending in 1,2,3 or 4");
         }
         String[] quarters = new String[] { "W", "S", "M", "F" };
         int index = yyyyq % 10;
@@ -130,46 +161,106 @@ public class Quarter {
     }
 
     /**
-     * Take yyyyq int format and return two digit year as a String
-     * Throw illegal argument exception if not in yyyyq format.
+     * Take yyyyq int format and return two digit year as a String Throw illegal
+     * argument exception if not in yyyyq format.
+     * 
      * @param yyyyq int (e.g. 20194 for Fall 2019)
      * @throws IllegalArgumentException
-     * @return two char string for year  (e.g. "19") 
+     * @return two char string for year (e.g. "19")
      */
     public static String getYY(int yyyyq) {
         if (invalidQtr(yyyyq)) {
-            throw new IllegalArgumentException("Argument should be a five digit integer in qqqqy format ending in 1,2,3 or 4");
+            throw new IllegalArgumentException(
+                    "Argument should be a five digit integer in qqqqy format ending in 1,2,3 or 4");
         }
-        return String.format("%02d", (yyyyq / 10) % 100);
+        return String
+                .format("%02d", (yyyyq / 10) % 100);
     }
 
     /**
-     * Take yyyyq int format and return four digit year as a String
-     * Throw illegal argument exception if not in yyyyq format.
+     * Take yyyyq int format and return four digit year as a String Throw illegal
+     * argument exception if not in yyyyq format.
+     * 
      * @param yyyyq int (e.g. 20194 for Fall 2019)
      * @throws IllegalArgumentException
-     * @return four char string for year  (e.g. "2019") 
+     * @return four char string for year (e.g. "2019")
      */
     public static String getYYYY(int yyyyq) {
         if (invalidQtr(yyyyq)) {
-            throw new IllegalArgumentException("Argument should be a five digit integer in qqqqy format ending in 1,2,3 or 4");
+            throw new IllegalArgumentException(
+                    "Argument should be a five digit integer in qqqqy format ending in 1,2,3 or 4");
         }
-        return String.format("%04d", (yyyyq / 10));
+        return String
+                .format("%04d", (yyyyq / 10));
     }
 
     public static int qyyToQyyyy(String qyy) {
-        if (qyy.length() !=3)
+        if (qyy
+                .length() != 3)
             throw new IllegalArgumentException("Argument shoudl be in QYY format");
 
-        char q = qyy.charAt(0);
-        String yy = qyy.substring(1, 3);
+        char q = qyy
+                .charAt(0);
+        String yy = qyy
+                .substring(1, 3);
         String legalQuarters = "WSMF";
-        int qInt = legalQuarters.indexOf(q) + 1;
+        int qInt = legalQuarters
+                .indexOf(q) + 1;
         if (invalidQtr(qInt)) {
             throw new IllegalArgumentException("First char should be one of " + legalQuarters);
         }
-        int yyInt = Integer.parseInt(yy);
+        int yyInt = Integer
+                .parseInt(yy);
         int century = (yyInt > 50) ? 1900 : 2000;
         return (century + yyInt) * 10 + qInt;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this)
+            return true;
+        if (!(o instanceof Quarter)) {
+            return false;
+        }
+        Quarter quarter = (Quarter) o;
+        return yyyyq == quarter.yyyyq;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(yyyyq);
+    }
+
+
+
+    /**
+     * return a list of Quarters starting with the start parameter and ending with the end parameter, inclusive.
+     *
+     * The result will automatically go in chronological or reverse chronological order, depending
+     * on the order of the parameters.
+     * @param start
+     * @param end
+     * @return list of quarters in specified order
+     */
+
+    public static List<Quarter> quarterList(String start, String end) {
+        List<Quarter> result = new ArrayList<Quarter>();
+
+        int startInt = Quarter.qyyToQyyyy(start);
+        int endInt = Quarter.qyyToQyyyy(end);
+
+        if (startInt <= endInt) {
+            for (Quarter iter = new Quarter(startInt); iter.getValue() <= endInt; iter.increment()) {
+                Quarter q = new Quarter(iter.getValue());
+                result.add(q);
+            }
+        } else {
+            for (Quarter iter = new Quarter(startInt); iter.getValue() >= endInt; iter.decrement()) {
+            Quarter q = new Quarter(iter.getValue());
+            result.add(q);
+            }
+        }
+        return result;
     }
 }

--- a/src/main/resources/templates/search/bycourse/fragments/form.html
+++ b/src/main/resources/templates/search/bycourse/fragments/form.html
@@ -9,16 +9,7 @@
         <label for="beginQ" class="col-sm-2 col-form-label">Begin Quarter</label>
         <div class="col-sm-10">
             <select th:field="*{beginQ}" class="custom-select">
-                <option selected="selected" value="20201">WINTER 2020</option>
-                <option value="20194">FALL 2019 </option>
-                <option value="20193">SUMMER 2019 </option>
-                <option value="20192">SPRING 2019 </option>
-                <option value="20191">WINTER 2019 </option>
-                <option value="20184">FALL 2018 </option>
-                <option value="20183">SUMMER 2018 </option>
-                <option value="20182">SPRING 2018 </option>
-                <option value="20181">WINTER 2018 </option>
-                <option value="20174">FALL 2017 </option>
+                <option th:each="q: ${quarters}" th:value="${q.value}" th:text="${q}"></option>
             </select>
         </div>
     </div>
@@ -26,16 +17,7 @@
         <label for="endQ" class="col-sm-2 col-form-label">End Quarter</label>
         <div class="col-sm-10">
             <select th:field="*{endQ}" class="custom-select">
-                <option selected="selected" value="20201">WINTER 2020</option>
-                <option value="20194">FALL 2019 </option>
-                <option value="20193">SUMMER 2019 </option>
-                <option value="20192">SPRING 2019 </option>
-                <option value="20191">WINTER 2019 </option>
-                <option value="20184">FALL 2018 </option>
-                <option value="20183">SUMMER 2018 </option>
-                <option value="20182">SPRING 2018 </option>
-                <option value="20181">WINTER 2018 </option>
-                <option value="20174">FALL 2017 </option>
+                <option th:each="q: ${quarters}" th:value="${q.value}" th:text="${q}"></option>
             </select>
         </div>
     </div>

--- a/src/test/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/utilities/TestQuarter.java
+++ b/src/test/java/edu/ucsb/cs56/ucsbapi/academics/curriculums/utilities/TestQuarter.java
@@ -109,6 +109,36 @@ public class TestQuarter {
         assertEquals("F20", q.toString());
     }
 
+
+    @Test
+    public void test_decrement_F19() {
+        Quarter q = new Quarter("F19");
+        assertEquals(20193, q.decrement());
+        assertEquals("M19", q.toString());
+    }
+
+    @Test
+    public void test_decrement_W20() {
+        Quarter q = new Quarter("W20");
+        assertEquals(20194, q.decrement());
+        assertEquals("F19", q.toString());
+    }
+
+    @Test
+    public void test_decrement_S20() {
+        Quarter q = new Quarter("S20");
+        assertEquals(20201, q.decrement());
+        assertEquals("W20", q.toString());
+    }
+
+    @Test
+    public void test_decrement_M20() {
+        Quarter q = new Quarter("M20");
+        assertEquals(20202, q.decrement());
+        assertEquals("S20", q.toString());
+    }
+
+
     // TEST STATIC METHODS
 
     @Test
@@ -220,4 +250,24 @@ public class TestQuarter {
     public void test_qyyToQyyyy__badChar() {
         Quarter.qyyToQyyyy("F2X");
     }
+
+    @Test
+    public void test_quarterList_S20_F19() {
+        ArrayList<Quarter> expected = new ArrayList<Quarter>();
+        expected.add(new Quarter("S20"));
+        expected.add(new Quarter("W20"));
+        expected.add(new Quarter("F19"));
+        assertEquals(expected, Quarter.quarterList("S20","F19"));
+    }
+
+    @Test
+    public void test_quarterList_F19_S20() {
+        List<Quarter> expected = new ArrayList<Quarter>();
+        expected.add(new Quarter("F19"));
+        expected.add(new Quarter("W20"));
+        expected.add(new Quarter("S20"));
+       
+        assertEquals(expected, Quarter.quarterList("F19","S20"));
+    }
+
 }


### PR DESCRIPTION
In this PR, we add a programatic way to generate lists of quarters in forward or reverse chronological order, to use in populating drop down lists.

This PR only puts this into the byCourse search.  Adding it to the other searches can be done later.